### PR TITLE
Deploying `master` to Heroku

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,13 @@ test:
   override:
     - npm run lint
     - npm run test:server
-    - npm run build
+    - NODE_ENV=production npm run build
     - npm start:
         background: true
     - npm run test:e2e
+
+deployment:
+  production:
+    branch: heroku
+    commands:
+      - git push -f git@heroku.com:redbadger-next.git $CIRCLE_SHA1:master

--- a/config/common.webpack.config.js
+++ b/config/common.webpack.config.js
@@ -2,11 +2,6 @@ const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const plugins = [
-  new webpack.DefinePlugin({
-    'process.env': {
-      NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development')
-    }
-  }),
   new ExtractTextPlugin('style.css'),
   new webpack.NoErrorsPlugin(),
   new webpack.optimize.DedupePlugin()

--- a/config/karma.config.js
+++ b/config/karma.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const commonConfig = require('./common.webpack.config.js');
 
 module.exports = function(config) {
@@ -12,7 +13,16 @@ module.exports = function(config) {
             '../src/**/*.js': ['webpack']
         },
 
-        webpack: commonConfig,
+        webpack: Object.assign({}, commonConfig, {
+          plugins: [
+            ...commonConfig.plugins,
+            new webpack.DefinePlugin({
+              'process.env': {
+                NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development')
+              }
+            })
+          ]
+        }),
 
         webpackMiddleware: {
             noInfo: true

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -11,6 +11,7 @@
  * times on the server.
  */
 
+const webpack = require('webpack');
 const commonConfig = require('./common.webpack.config.js');
 const cssnext = require('postcss-cssnext');
 const dedupe = require('postcss-discard-duplicates');
@@ -22,24 +23,34 @@ const coreConfig = Object.assign({
 }, commonConfig);
 
 const config = [
-  Object.assign({
+  Object.assign({}, coreConfig, {
     name: 'server',
     target: 'node',
+    externals: /^[a-z\-0-9]+$/,
     entry: ['./src/server.js'],
     output: {
       path: 'build',
-      filename: 'server.js'
+      filename: 'server.js',
+      libraryTarget: 'commonjs2'
     }
-  }, coreConfig),
-  Object.assign({
+  }),
+  Object.assign({}, coreConfig, {
     name: 'client',
     target: 'web',
     entry: ['./src/client.js'],
     output: {
       path: 'build',
       filename: 'client.js'
-    }
-  }, coreConfig)
+    },
+    plugins: [
+      ...coreConfig.plugins,
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development')
+        }
+      })
+    ]
+  })
 ];
 
 module.exports = config;


### PR DESCRIPTION
Now deploying to https://redbadger-next.herokuapp.com
- [x] Set up Heroku app on my personal account (only temporary as we'll be going on AWS soon)
- [x] Doing a production build in CircleCI (for e2e tests)
- [x] Server-side webpack bundle no longer packages `node_modules`
- [x] Made sure environment variables at runtime pass to server-side code (removed use of `DefinePlugin` for server and told Webpack to pass through `global`, `process`, `__dirname`, etc.)
- [x] Forked a Heroku build pack for webpack (https://github.com/redbadger/heroku-buildpack-webpack) so that we could build webpack assets on deploy

![](http://i.imgur.com/UjsZU5n.gif)
