### PR TITLE
Added ESLint caching and linting more files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+build/**
+static/**

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node build/server.js",
     "build": "webpack --config config/webpack.config.js",
     "watch": "webpack --config config/webpack.config.js --watch",
-    "lint": "eslint -c .eslintrc ./src/**"
+    "lint": "eslint --cache ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We were only linting files within `src` but our `config` and tests weren't being linted. This change will invert this so we check everything by default except the `node_modules`, `build` and `static` directories. The caching option will cause ESLint to only check files that we're changed.

![](http://i.imgur.com/JxEMhYO.gif)