### PR TITLE
Use the 'real' html-to-react library

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "classnames": "^2.2.1",
     "dotenv": "^1.2.0",
     "express": "^4.13.3",
-    "html-to-react": "git+https://github.com/lithin/html-to-react.git#2a1f129944af561ea6616390ce9a41019e2074b3",
+    "html-to-react": "^0.1.2",
     "lodash": "^4.0.0",
     "moment": "^2.10.6",
     "node-fetch": "^1.3.3",


### PR DESCRIPTION
My key warning fix was merged into that library so I'm swapping back to it.