### PR TITLE
Migrate to class syntax

### DIFF
--- a/src/shared/components/badge/index.js
+++ b/src/shared/components/badge/index.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './style.css';
 
-export default function Badge () {
-  return (
-    <span className={styles.badge}></span>
-  );
+export default class Badge extends Component {
+  render () {
+    return (
+      <span className={styles.badge}></span>
+    );
+  }
 }

--- a/src/shared/components/button/index.js
+++ b/src/shared/components/button/index.js
@@ -1,23 +1,26 @@
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import styles from './style.css';
 
-export default function Button (props) {
-  let { className, ...other } = props;
-  const buttonClass = classNames(className, styles.button);
-  
-  if (props.href) {
+export default class Button extends Component {
+  static propTypes = {
+    className: React.PropTypes.string,
+    href: React.PropTypes.string
+  };
+
+  render () {
+    let { className, ...other } = this.props;
+    const buttonClass = classNames(className, styles.button);
+
+    if (this.props.href) {
+      return (
+        <a {...other} className={buttonClass}></a>
+      );
+    }
+
     return (
-      <a {...other} className={buttonClass}></a>
+      <button {...other} className={buttonClass}></button>
     );
   }
 
-  return (
-    <button {...other} className={buttonClass}></button>
-  );
 }
-
-Button.propTypes = {
-  className: React.PropTypes.string,
-  href: React.PropTypes.string
-};

--- a/src/shared/components/component-renderer/index.js
+++ b/src/shared/components/component-renderer/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import Paragraph from './paragraph';
 import Link from './link';
 import Strong from './strong';
@@ -19,7 +19,13 @@ const componentIndex = {
   Title3: Title3
 };
 
-export default class ComponentRenderer extends React.Component {
+export default class ComponentRenderer extends Component {
+  static propTypes = {
+    data: React.PropTypes.shape({
+      type: React.PropTypes.string
+    }).isRequired
+  };
+
   build (data) {
     const componentName = data.type;
     const Component = componentIndex[componentName];
@@ -47,9 +53,3 @@ export default class ComponentRenderer extends React.Component {
     return this.build(this.props.data);
   }
 }
-
-ComponentRenderer.propTypes = {
-  data: React.PropTypes.shape({
-    type: React.PropTypes.string
-  }).isRequired
-};

--- a/src/shared/components/component-renderer/link.js
+++ b/src/shared/components/component-renderer/link.js
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './styles.css';
 
-export default function Link (props) {
-  return <a className={styles.a} href={props.href}>{props.children}</a>;
-}
+export default class Link extends Component {
+  static propTypes = {
+    children: React.PropTypes.node,
+    href: React.PropTypes.string.isRequired
+  };
 
-Link.propTypes = {
-  children: React.PropTypes.node,
-  href: React.PropTypes.string.isRequired
-};
+  render () {
+    return (
+      <a className={styles.a} href={this.props.href}>{this.props.children}</a>
+    );
+  }
+}

--- a/src/shared/components/component-renderer/paragraph.js
+++ b/src/shared/components/component-renderer/paragraph.js
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { Component } from 'react';
 import * as textStyles from '../utils/text.css';
 import styles from './styles.css';
 import classNames from 'classnames';
 
-export default function Paragraph (props) {
-  const pClass = classNames(textStyles[props.align], styles.p);
-  return <p className={pClass}>{props.children}</p>;
-}
+export default class Paragraph extends Component {
+  static propTypes = {
+    align: React.PropTypes.oneOf(['center', 'left', 'right']),
+    children: React.PropTypes.node
+  };
 
-Paragraph.propTypes = {
-  align: React.PropTypes.oneOf(['center', 'left', 'right']),
-  children: React.PropTypes.node
-};
+  render () {
+    const pClass = classNames(textStyles[this.props.align], styles.p);
+    return <p className={pClass}>{this.props.children}</p>;
+  }
+}

--- a/src/shared/components/component-renderer/strong.js
+++ b/src/shared/components/component-renderer/strong.js
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default function Paragraph (props) {
-  return <strong>{props.children}</strong>;
+export default class Paragraph extends Component {
+  static propTypes = {
+    children: React.PropTypes.node.isRequired
+  };
+
+  render () {
+    return <strong>{this.props.children}</strong>;
+  }
 }
-
-Paragraph.propTypes = {
-  children: React.PropTypes.node.isRequired
-};

--- a/src/shared/components/component-renderer/title1.js
+++ b/src/shared/components/component-renderer/title1.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './styles.css';
 
-export default function Title1 (props) {
-  return <h1 className={styles.h1}>{props.children}</h1>;
-}
+export default class Title1 extends Component {
+  static propTypes = {
+    children: React.PropTypes.node
+  };
 
-Title1.propTypes = {
-  children: React.PropTypes.node
-};
+  render () {
+    return <h1 className={styles.h1}>{this.props.children}</h1>;
+  }
+}

--- a/src/shared/components/component-renderer/title2.js
+++ b/src/shared/components/component-renderer/title2.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './styles.css';
 
-export default function Title2 (props) {
-  return <h2 className={styles.h2}>{props.children}</h2>;
-}
+export default class Title2 extends Component {
+  static propTypes = {
+    children: React.PropTypes.node
+  };
 
-Title2.propTypes = {
-  children: React.PropTypes.node
-};
+  render () {
+    return <h2 className={styles.h2}>{this.props.children}</h2>;
+  }
+}

--- a/src/shared/components/component-renderer/title3.js
+++ b/src/shared/components/component-renderer/title3.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './styles.css';
 
-export default function Title3 (props) {
-  return <h3 className={styles.h3}>{props.children}</h3>;
-}
+export default class Title3 extends Component {
+  static propTypes = {
+    children: React.PropTypes.node
+  };
 
-Title3.propTypes = {
-  children: React.PropTypes.node
-};
+  render () {
+    return <h3 className={styles.h3}>{this.props.children}</h3>;
+  }
+}

--- a/src/shared/components/container/index.js
+++ b/src/shared/components/container/index.js
@@ -1,16 +1,22 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './style.css';
 
-export default function Container ({children}) {
-  return (
-    <div className={styles.wrapper}>
-      <div className={styles.container}>
-        {children}
-      </div>
-    </div>
-  );
-}
+export default class Container extends Component {
+  static propTypes = {
+    children: React.PropTypes.node
+  };
 
-Container.propTypes = {
-  children: React.PropTypes.node
-};
+  static defaultProps = {
+    children: []
+  };
+
+  render () {
+    return (
+      <div className={styles.wrapper}>
+        <div className={styles.container}>
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/shared/components/content/index.js
+++ b/src/shared/components/content/index.js
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default function Content ({children}) {
-  return (
-    <div>
-      {children}
-    </div>
-  );
+export default class Content extends Component {
+  static propTypes = {
+    children: React.PropTypes.node
+  };
+
+  render () {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    );
+  }
 }
-
-Content.propTypes = {
-  children: React.PropTypes.node
-};

--- a/src/shared/components/footer/index.js
+++ b/src/shared/components/footer/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import Container from '../container';
 import { Grid, Cell } from '../grid';
@@ -8,82 +8,84 @@ import styles from './style.css';
 import * as icons from '../icons/style.css';
 import * as display from '../utils/display.css';
 
-export default function Footer () {
-  return (
-    <footer className={styles.footer}>
-      <Container>
-        <Grid fit>
+export default class Footer extends Component {
+  render () {
+    return (
+      <footer className={styles.footer}>
+        <Container>
+          <Grid fit>
 
-          <Cell>
-            <address className={styles.address}>
-              <strong>Red Badger Consulting Limited</strong>
-              <br/>
-              <span>12 Mallow Street</span>
-              <br/>
-              <span>London EC1Y 8RQ</span>
-              <br/>
-              <a className={styles.contactUsLink} href="/about-us/contact-us">
-                Contact us >
-              </a>
-            </address>
-          </Cell>
+            <Cell>
+              <address className={styles.address}>
+                <strong>Red Badger Consulting Limited</strong>
+                <br/>
+                <span>12 Mallow Street</span>
+                <br/>
+                <span>London EC1Y 8RQ</span>
+                <br/>
+                <a className={styles.contactUsLink} href="/about-us/contact-us">
+                  Contact us >
+                </a>
+              </address>
+            </Cell>
 
-          <Cell>
-            <ul className={styles.links} >
-              <li>
-                <a className={styles.contactLink} href="mailto:hello@red-badger.com">
-                  <span className={classNames(styles.iconCyan, icons.sketchEmail)} ></span>
-                  {' hello@red-badger.com'}
-                </a>
-              </li>
-              <li>
-                <a className={styles.socialLink} href="http://twitter.com/redbadgerteam">
-                  <span className={classNames(styles.icon, icons.socialTwitter)}></span>
-                  {' @redbadgerteam'}
-                </a>
-              </li>
-              <li>
-                <a className={styles.socialLink} href="http://www.facebook.com/RedBadger">
-                  <span className={classNames(styles.icon, icons.socialFacebook)}></span>
-                  {' facebook'}
-                </a>
-              </li>
-              <li>
-                <a className={styles.socialLink} href="http://www.linkedin.com/companies/red-badger">
-                  <span className={classNames(styles.icon, icons.socialLinkedin)}></span>
-                  {' linkedin'}
-                </a>
-              </li>
-              <li>
-                <a className={styles.socialLink} href="https://instagram.com/redbadgerteam">
-                  <span className={classNames(styles.icon, icons.socialInstagram)}></span>
-                  {' instagram'}
-                </a>
-              </li>
-            </ul>
-          </Cell>
+            <Cell>
+              <ul className={styles.links} >
+                <li>
+                  <a className={styles.contactLink} href="mailto:hello@red-badger.com">
+                    <span className={classNames(styles.iconCyan, icons.sketchEmail)} ></span>
+                    {' hello@red-badger.com'}
+                  </a>
+                </li>
+                <li>
+                  <a className={styles.socialLink} href="http://twitter.com/redbadgerteam">
+                    <span className={classNames(styles.icon, icons.socialTwitter)}></span>
+                    {' @redbadgerteam'}
+                  </a>
+                </li>
+                <li>
+                  <a className={styles.socialLink} href="http://www.facebook.com/RedBadger">
+                    <span className={classNames(styles.icon, icons.socialFacebook)}></span>
+                    {' facebook'}
+                  </a>
+                </li>
+                <li>
+                  <a className={styles.socialLink} href="http://www.linkedin.com/companies/red-badger">
+                    <span className={classNames(styles.icon, icons.socialLinkedin)}></span>
+                    {' linkedin'}
+                  </a>
+                </li>
+                <li>
+                  <a className={styles.socialLink} href="https://instagram.com/redbadgerteam">
+                    <span className={classNames(styles.icon, icons.socialInstagram)}></span>
+                    {' instagram'}
+                  </a>
+                </li>
+              </ul>
+            </Cell>
 
-          <Cell>
-            <h4 className={styles.newsletterHeading}>Join our newsletter</h4>
-            <form action="//red-badger.us6.list-manage.com/subscribe/post?u=0ab76cd515&amp;amp;id=b20af1dc4e" className={styles.todo} method="post" >
-              <label>
-                Suscribe to receive news, ideas and lessons learned from Red Badger
-              </label>
-              <div className={styles.inputContainer}>
-                <Input className={styles.inputText} name="EMAIL" placeholder="Enter your email" type="text"/>
-                <Button className={styles.inputSubmit} type="submit">Subscribe</Button>
-                <div className={display.hiddenVisually}>
-                  <input name="b_0ab76cd515_b20af1dc4e" tabIndex="-1" type="text" value=""/>
+            <Cell>
+              <h4 className={styles.newsletterHeading}>Join our newsletter</h4>
+              <form action="//red-badger.us6.list-manage.com/subscribe/post?u=0ab76cd515&amp;amp;id=b20af1dc4e" className={styles.todo} method="post" >
+                <label>
+                  Suscribe to receive news, ideas and lessons learned from Red Badger
+                </label>
+                <div className={styles.inputContainer}>
+                  <Input className={styles.inputText} name="EMAIL" placeholder="Enter your email" type="text"/>
+                  <Button className={styles.inputSubmit} type="submit">Subscribe</Button>
+                  <div className={display.hiddenVisually}>
+                    <input name="b_0ab76cd515_b20af1dc4e" tabIndex="-1" type="text" value=""/>
+                  </div>
                 </div>
+              </form>
+              <div>
+                <span>© Red Badger All Rights Reserved</span>
               </div>
-            </form>
-            <div>
-              <span>© Red Badger All Rights Reserved</span>
-            </div>
-          </Cell>
+            </Cell>
 
-        </Grid>
-      </Container>
-    </footer>
-  );
+          </Grid>
+        </Container>
+      </footer>
+    );
+  }
 }

--- a/src/shared/components/grid/cell.js
+++ b/src/shared/components/grid/cell.js
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import React, { Component } from 'react';
+import styles from './style.css';
+
+export default class Cell extends Component {
+  static propTypes = {
+    children: React.PropTypes.node,
+    size: React.PropTypes.number
+  };
+
+  render () {
+    const cellClassNames = classNames(
+      {
+        [styles.cell]: true,
+        [styles['size' + this.props.size + 'of12']]: !!this.props.size
+      }
+    );
+
+    return (
+      <div className={cellClassNames}>
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/src/shared/components/grid/index.js
+++ b/src/shared/components/grid/index.js
@@ -17,45 +17,31 @@
  */
 
 /*eslint react/no-multi-comp:0*/
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import styles from './style.css';
 
-export function Grid ({children, fit}) {
-  const gridClassNames = classNames(
-    {
-      [styles.grid]: true,
-      [styles.withGutter]: true,
-      [styles.fit]: fit
-    }
-  );
-  return (
-    <div className={gridClassNames}>
-      {children}
-    </div>
-  );
+export class Grid extends Component {
+  static propTypes = {
+    children: React.PropTypes.node,
+    fit: React.PropTypes.bool
+  };
+
+  render () {
+    const gridClassNames = classNames(
+      {
+        [styles.grid]: true,
+        [styles.withGutter]: true,
+        [styles.fit]: this.props.fit
+      }
+    );
+
+    return (
+      <div className={gridClassNames}>
+        {this.props.children}
+      </div>
+    );
+  }
 }
 
-Grid.propTypes = {
-  children: React.PropTypes.node,
-  fit: React.PropTypes.bool
-};
-
-export function Cell ({children, size}) {
-  const cellClassNames = classNames(
-    {
-      [styles.cell]: true,
-      [styles['size' + size + 'of12']]: !!size
-    }
-  );
-  return (
-    <div className={cellClassNames}>
-      {children}
-    </div>
-  );
-}
-
-Cell.propTypes = {
-  children: React.PropTypes.node,
-  size: React.PropTypes.number
-};
+export Cell from './cell.js';

--- a/src/shared/components/header/index.js
+++ b/src/shared/components/header/index.js
@@ -1,18 +1,20 @@
-import React from 'react';
+import React, { Component } from 'react';
 import Container from '../container';
 import Logo from '../logo';
 import Nav from '../nav';
 import styles from './style.css';
 
-export default function Header () {
-  return (
-    <header className={styles.header}>
-      <Container>
-        <a className={styles.logo} href="/">
-          <Logo />
-        </a>
-      </Container>
-      <Nav/>
-    </header>
-  );
+export default class Header extends Component {
+  render () {
+    return (
+      <header className={styles.header}>
+        <Container>
+          <a className={styles.logo} href="/">
+            <Logo />
+          </a>
+        </Container>
+        <Nav/>
+      </header>
+    );
+  }
 }

--- a/src/shared/components/hr/index.js
+++ b/src/shared/components/hr/index.js
@@ -1,19 +1,21 @@
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import styles from './style.css';
 
-export default function HR ({ color }) {
-  const hrClass = classNames({
-    [styles.hr]: true,
-    [styles.red]: (color === 'red'),
-    [styles.grey]: (color === 'grey')
-  });
+export default class HR extends Component {
+  static propTypes = {
+    color: React.PropTypes.oneOf(['red', 'grey'])
+  };
 
-  return (
-    <hr className={hrClass} />
-  );
+  render () {
+    const hrClass = classNames({
+      [styles.hr]: true,
+      [styles.red]: (this.props.color === 'red'),
+      [styles.grey]: (this.props.color === 'grey')
+    });
+
+    return (
+      <hr className={hrClass} />
+    );
+  }
 }
-
-HR.propTypes = {
-  color: React.PropTypes.oneOf(['red', 'grey'])
-};

--- a/src/shared/components/html-parser/index.js
+++ b/src/shared/components/html-parser/index.js
@@ -1,14 +1,15 @@
-import React from 'react';
+import React, { Component } from 'react';
 import HtmlToReact from 'html-to-react';
 import styles from '../typography/style.css';
 
 const { parse } = new HtmlToReact.Parser(React);
 
-export default function HtmlParser ({children}) {
-  const content = parse('<div class="' + styles.typography + '">' + children + '</div>');
-  return content;
-}
+export default class HtmlParser extends Component {
+  static propTypes = {
+    children: React.PropTypes.string.isRequired
+  };
 
-HtmlParser.propTypes = {
-  children: React.PropTypes.string.isRequired
-};
+  render () {
+    return parse('<div class="' + styles.typography + '">' + this.props.children + '</div>');
+  }
+}

--- a/src/shared/components/input/index.js
+++ b/src/shared/components/input/index.js
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import styles from './style.css';
 
-export default function Input ({ className, ...other }) {
-  const inputClass = classNames(className, styles.input);
+export default class Input extends Component {
+  render () {
+    const {className, ...other} = this.props;
+    const inputClass = classNames(className, styles.input);
 
-  return (
-    <input {...other} className={inputClass}></input>
-  );
+    return (
+      <input {...other} className={inputClass}></input>
+    );
+  }
 }
 
 Input.propTypes = {

--- a/src/shared/components/jobs/index.js
+++ b/src/shared/components/jobs/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import Note from '../note';
 import HtmlParser from '../html-parser';
 import styles from './style.css';
@@ -6,31 +6,33 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import Wall from '../wall';
 
-export function Jobs ({jobs}) {
-  const listings = jobs.map((job, index) => {
+export class Jobs extends Component {
+  static propTypes = {
+    jobs: React.PropTypes.arrayOf(React.PropTypes.shape({
+      description: React.PropTypes.string,
+      title: React.PropTypes.string
+    }))
+  };
+
+  render () {
+    const listings = this.props.jobs.map((job, index) => {
+      return (
+        <Note key={index}>
+          <Link className={styles.title} to={'/about-us/join-us/' + job.slug}>{job.title}<span className={styles.icon}></span></Link>
+          <HtmlParser>{job.description}</HtmlParser>
+        </Note>
+      );
+    });
+
     return (
-      <Note key={index}>
-        <Link className={styles.title} to={'/about-us/join-us/' + job.slug}>{job.title}<span className={styles.icon}></span></Link>
-        <HtmlParser>{job.description}</HtmlParser>
-      </Note>
+      <div className="jobs">
+        <Wall cols={3}>
+          {listings}
+        </Wall>
+      </div>
     );
-  });
-
-  return (
-    <div className="jobs">
-      <Wall cols={3}>
-        {listings}
-      </Wall>
-    </div>
-  );
+  }
 }
-
-Jobs.propTypes = {
-  jobs: React.PropTypes.arrayOf(React.PropTypes.shape({
-    description: React.PropTypes.string,
-    title: React.PropTypes.string
-  }))
-};
 
 export default connect((state) => {
   return {

--- a/src/shared/components/layout/index.js
+++ b/src/shared/components/layout/index.js
@@ -1,17 +1,19 @@
-import React from 'react';
+import React, { Component } from 'react';
 import Header from '../header';
 import Footer from '../footer';
 
-export default function Layout ({children}) {
-  return (
-    <div>
-      <Header />
-      {children}
-      <Footer />
-    </div>
-  );
-}
+export default class Layout extends Component {
+  static propTypes = {
+    children: React.PropTypes.node
+  };
 
-Layout.propTypes = {
-  children: React.PropTypes.node
-};
+  render () {
+    return (
+      <div>
+        <Header />
+        {this.props.children}
+        <Footer />
+      </div>
+    );
+  }
+}

--- a/src/shared/components/logo/index.js
+++ b/src/shared/components/logo/index.js
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './style.css';
 import image from './logo.png';
 
-export default function Logo () {
-  return (
-    <img alt="Red Badger Logo" className={styles.logo} src={image} />
-  );
+export default class Logo extends Component {
+  render () {
+    return (
+      <img alt="Red Badger Logo" className={styles.logo} src={image} />
+    );
+  }
+
 }

--- a/src/shared/components/nav-item/index.js
+++ b/src/shared/components/nav-item/index.js
@@ -1,23 +1,19 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './style.css';
 
-export default function NavItem ({active, href, title}) {
-  let activeElement;
+export default class NavItem extends Component {
+  static propTypes = {
+    active: React.PropTypes.bool,
+    href: React.PropTypes.string.isRequired,
+    title: React.PropTypes.string.isRequired
+  };
 
-  if (active) {
-    activeElement = <div className={styles.active}></div>;
+  render () {
+    return (
+      <li className={styles.navItem}>
+        <a className={styles.navItemLink} href={this.props.href}>{this.props.title}</a>
+        {(this.props.active ? <div className={styles.active} /> : undefined)}
+      </li>
+    );
   }
-
-  return (
-    <li className={styles.navItem}>
-      <a className={styles.navItemLink} href={href}>{title}</a>
-      {activeElement}
-    </li>
-  );
 }
-
-NavItem.propTypes = {
-  active: React.PropTypes.bool,
-  href: React.PropTypes.string.isRequired,
-  title: React.PropTypes.string.isRequired
-};

--- a/src/shared/components/nav/index.js
+++ b/src/shared/components/nav/index.js
@@ -1,12 +1,12 @@
 /*eslint react/no-set-state:0*/
 /* eslint react/no-did-mount-set-state: 0 */
-import React from 'react';
+import React, { Component } from 'react';
 import Badge from '../badge';
 import NavItem from '../nav-item';
 import styles from './style.css';
 import classNames from 'classnames';
 
-export default class Nav extends React.Component {
+export default class Nav extends Component {
   constructor (props) {
     super(props);
 

--- a/src/shared/components/note/index.js
+++ b/src/shared/components/note/index.js
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './style.css';
 
-export default function Note ({children}) {
-  return (
-    <div className={styles.note}>
-      {children}
-    </div>
-  );
-}
+export default class Note extends Component {
+  static propTypes = {
+    children: React.PropTypes.node.isRequired
+  };
 
-Note.propTypes = {
-  children: React.PropTypes.node.isRequired
-};
+  render () {
+    return (
+      <div className={styles.note}>
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/src/shared/components/section/index.js
+++ b/src/shared/components/section/index.js
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { Component } from 'react';
 import styles from './style.css';
 
-export default function Section ({children}) {
-  return (
-    <section className={styles.section}>
-      {children}
-    </section>
-  );
-}
+export default class Section extends Component {
+  static propTypes = {
+    children: React.PropTypes.node
+  };
 
-Section.propTypes = {
-  children: React.PropTypes.node
-};
+  render () {
+    return (
+      <section className={styles.section}>
+        {this.props.children}
+      </section>
+    );
+  }
+}

--- a/src/shared/components/video/index.js
+++ b/src/shared/components/video/index.js
@@ -1,21 +1,24 @@
-import React from 'react';
+import React, { Component } from 'react';
 // The plan is to only use youtube in future so we declare the styles there.
 import styles from './style.css';
 
-export default function Video ({type, id}) {
-  const urlMap = {
+export default class Video extends Component {
+  static propTypes = {
+    id: React.PropTypes.string.isRequired,
+    type: React.PropTypes.oneOf(['vimeo', 'youtube']).isRequired
+  };
+
+  static urlMap = {
     vimeo: 'https://player.vimeo.com/video/',
     youtube: 'https://www.youtube.com/embed/'
   };
-  const source = urlMap[type] + id;
-  return (
-    <div className={styles.container}>
-      <iframe allowFullScreen className={styles.embed} frameBorder="0" src={source}></iframe>
-    </div>
-  );
-}
 
-Video.propTypes = {
-  id: React.PropTypes.string.isRequired,
-  type: React.PropTypes.oneOf(['vimeo', 'youtube']).isRequired
-};
+  render () {
+    const source = Video.urlMap[this.props.type] + this.props.id;
+    return (
+      <div className={styles.container}>
+        <iframe allowFullScreen className={styles.embed} frameBorder="0" src={source}></iframe>
+      </div>
+    );
+  }
+}

--- a/src/shared/components/wall/index.js
+++ b/src/shared/components/wall/index.js
@@ -1,31 +1,32 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Grid, Cell } from '../grid';
 
 const { node, number } = React.PropTypes;
 
-export default function Wall ({ cols, children }) {
-  const elements = [];
+export default class Wall extends Component {
+  static propTypes = {
+    children: node.isRequired,
+    cols: number.isRequired
+  };
 
-  children.forEach((item, index) => {
-    const field = index % cols;
+  render () {
+    const elements = [];
+    this.props.children.forEach((item, index) => {
+      const field = index % this.props.cols;
 
-    if (field >= elements.length) {
-      elements[field] = [];
-    }
+      if (field >= elements.length) {
+        elements[field] = [];
+      }
 
-    elements[field].push(item);
-  });
+      elements[field].push(item);
+    });
 
-  return (
-    <Grid fit>
-      {elements.map((column, index) => {
-        return (<Cell key={index} size={Math.floor(12/cols)}>{column}</Cell>);
-      })}
-    </Grid>
-  );
+    return (
+      <Grid fit>
+        {elements.map((column, index) => {
+          return (<Cell key={index} size={Math.floor(12/this.props.cols)}>{column}</Cell>);
+        })}
+      </Grid>
+    );
+  }
 }
-
-Wall.propTypes = {
-  children: node.isRequired,
-  cols: number.isRequired
-};

--- a/src/shared/containers/error/index.js
+++ b/src/shared/containers/error/index.js
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { Component } from 'react';
 
-export default function ErrorPage ({ children }) {
-  return (
-    <h1>{children || 'Not found'}</h1>
-  );
+export default class ErrorPage extends Component {
+  static propTypes = {
+    children: React.PropTypes.node
+  };
+
+  render () {
+    return (
+      <h1>{this.props.children || 'Not found'}</h1>
+    );
+  }
 }

--- a/src/shared/containers/job/index.js
+++ b/src/shared/containers/job/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import HtmlParser from '../../components/html-parser';
 import { Grid, Cell } from '../../components/grid';
@@ -11,42 +11,47 @@ import typography from '../../components/typography/style.css';
 import { Link } from 'react-router';
 import { filter, flow, head, property } from 'lodash/fp';
 import isEqual from 'lodash/isEqual'; // lodash fp isEqual is broken in 4.0.0
-import ErrorPage from '../error';
 import fetch from '../../util/fetch-proxy';
 import { fetchJobs } from '../../actions/jobs';
 
-export function Job ({ job }) {
-  if (job) {
+export class Job extends Component {
+  static propTypes = {
+    job: React.PropTypes.shape({
+      title: React.PropTypes.string,
+      fullDescription: React.PropTypes.string,
+      applicationUrl: React.PropTypes.string
+    })
+  };
+
+  static fetchData = fetchJobs(fetch());
+
+  render () {
     return (
       <Section>
         <Container>
           <Grid>
             <Cell size={8}>
-              <h2 className={typography.h2}>{job.title}</h2>
-              <HtmlParser>{job.fullDescription}</HtmlParser>
+              <h2 className={typography.h2}>{this.props.job.title}</h2>
+              <HtmlParser>{this.props.job.fullDescription}</HtmlParser>
               <HR color="grey" />
               <Link className={typography.aBold} to="/about-us/join-us"><span className={styles.linkBackArrow}></span>See all vacancies</Link>
-              <a className={styles.applyLink} href={job.applicationUrl} id="e2eApply" target="_blank">Apply here<span className={styles.externalIcon}></span></a>
+              <a className={styles.applyLink} href={this.props.job.applicationUrl} id="e2eApply" target="_blank">Apply here<span className={styles.externalIcon}></span></a>
             </Cell>
             <Cell size={4}>
-              <div className={styles.noteWrapper}>
-                <Note>
-                  <h2 className={styles.noteTitle}>How to Apply</h2>
-                  <p className={typography.p}>
-                    {"If you'd like to know more or you want to apply please get in touch with your CV, Stackoverflow profile, Github, code, portfolio and anything else you think we might be interested in."}
-                  </p>
-                  <p>
-                    <a className={typography.aBold} href={job.applicationUrl} target="_blank">Apply here <span className={styles.externalIcon}></span></a>
-                  </p>
-                </Note>
-              </div>
+              <Note>
+                <h2 className={styles.noteTitle}>How to Apply</h2>
+                <p className={typography.p}>
+                  {"If you'd like to know more or you want to apply please get in touch with your CV, Stackoverflow profile, Github, code, portfolio and anything else you think we might be interested in."}
+                </p>
+                <p>
+                  <a className={typography.aBold} href={this.props.job.applicationUrl} target="_blank">Apply here <span className={styles.externalIcon}></span></a>
+                </p>
+              </Note>
             </Cell>
           </Grid>
         </Container>
       </Section>
     );
-  } else {
-    return (<ErrorPage>{"Sorry this job doesn't seem to exist!"}</ErrorPage>);
   }
 }
 
@@ -59,8 +64,6 @@ function firstWithSlug (slug) {
     head
   );
 }
-
-Job.fetchData = fetchJobs(fetch());
 
 // I think connect should be moved to make this component just care about
 // getting a job. React router should be doing a level of this so that

--- a/src/shared/containers/join-us/index.js
+++ b/src/shared/containers/join-us/index.js
@@ -1,6 +1,6 @@
 import ComponentRenderer from '../../components/component-renderer';
 import Container from '../../components/container';
-import React from 'react';
+import React, { Component } from 'react';
 import Jobs from '../../components/jobs';
 import Section from '../../components/section';
 import styles from './style.css';
@@ -88,36 +88,36 @@ const vacancies = {
   }
 };
 
-function JoinUs () {
-  return (
-    <div>
-      <Section>
-        <Container>
-          <ComponentRenderer data={titles} />
-          <Grid fit>
-            <Cell>
-              <ComponentRenderer data={join} />
-            </Cell>
-            <Cell>
-              <Video id="110925126" type="vimeo" />
-            </Cell>
-          </Grid>
-          <HR color="red" />
-          <ComponentRenderer data={vacancies} />
-          <Jobs />
-        </Container>
-      </Section>
-      <div className={styles.apply}>
+export default class JoinUs extends Component {
+  static fetchData = fetchJobs(fetch());
+
+  render () {
+    return (
+      <div>
         <Section>
           <Container>
-            <ComponentRenderer data={apply} />
+            <ComponentRenderer data={titles} />
+            <Grid fit>
+              <Cell>
+                <ComponentRenderer data={join} />
+              </Cell>
+              <Cell>
+                <Video id="110925126" type="vimeo" />
+              </Cell>
+            </Grid>
+            <HR color="red" />
+            <ComponentRenderer data={vacancies} />
+            <Jobs />
           </Container>
         </Section>
+        <div className={styles.apply}>
+          <Section>
+            <Container>
+              <ComponentRenderer data={apply} />
+            </Container>
+          </Section>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
-
-JoinUs.fetchData = fetchJobs(fetch());
-
-export default JoinUs;

--- a/src/shared/containers/root/index.js
+++ b/src/shared/containers/root/index.js
@@ -1,13 +1,30 @@
-import React from 'react';
+import classnames from 'classnames';
 import Layout from '../../components/layout';
+import React, { Component } from 'react';
 import styles from './style.css';
 
-export default function Root ({ children }) {
-  return (
-    <div className={styles.root}>
-      <Layout>
-        {children}
-      </Layout>
-    </div>
-  );
+export default class Root extends Component {
+  static propTypes = {
+    background: React.PropTypes.oneOf(["error", "none"]),
+    children: React.PropTypes.node
+  };
+
+  static defaultProps = {
+    background: "none",
+    children: []
+  };
+
+  render () {
+    const outerClass = classnames(styles.root, {
+      [styles['error-background']]: this.props.background === "error"
+    });
+
+    return (
+      <div className={outerClass}>
+        <Layout>
+          {this.props.children}
+        </Layout>
+      </div>
+    );
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,19 +53,22 @@ if (hot) {
     loaders: commonLoaders({
       'babel-loader': {
         query: {
-          presets: [ "es2015-webpack", "react", "stage-0" ]
-        },
-        plugins: ['react-transform', {
-          transforms: [{
-            transform: 'react-transform-hmr',
-            imports: ['react'],
-            // this is important for Webpack HMR:
-            locals: ['module']
-          }, {
-            transform: require.resolve('react-transform-catch-errors'),
-            imports: ['react', require.resolve('redbox-react')]
-          }]
-        }]
+          presets: [ "es2015-webpack", "react", "stage-0" ],
+          plugins: [['react-transform', {
+            transforms: [
+              {
+                transform: 'react-transform-hmr',
+                imports: ['react'],
+                // this is important for Webpack HMR:
+                locals: ['module']
+              },
+              {
+                transform: require.resolve('react-transform-catch-errors'),
+                imports: ['react', require.resolve('redbox-react')]
+              }
+            ]
+          }]]
+        }
       }
     }, [
       { test: /\.css$/, loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[name]-[local]-[hash:base64:5]!postcss-loader' }


### PR DESCRIPTION
This allows us to use [react-transform-hmr](https://github.com/gaearon/react-transform-hmr) which doesn't currently work with stateless function components, and enables hot loading of react components and their styles without a page refresh.

- [x] Convert to `class SomeComponent extends React.Component`
- [x] Enable HMR plugin in babel-loader when `HOT=true` (previously configured incorrectly)