### PR TITLE
Events page display past and upcoming events in 2 separate sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.2.0",
     "marked": "^0.3.5",
-    "moment": "^2.11.1",
+    "moment": "^2.13.0",
     "nano": "^6.2.0",
     "param-case": "^1.1.2",
     "query-string": "^3.0.0",

--- a/src/server/api/routes.js
+++ b/src/server/api/routes.js
@@ -1,11 +1,5 @@
 import { couchDbLocal, couchDbRemote } from '../../shared/config';
 
-// Using old school require because of https://github.com/moment/moment/issues/2608
-const moment = require('moment');
-
-const today = moment().toISOString();
-const fiveYearsFromNow = moment().add(5, 'years').toISOString();
-
 export default class Routes {
   constructor (workable) {
     this.workable = workable;
@@ -20,7 +14,7 @@ export default class Routes {
   };
 
   getEvents = (req, res) => {
-    fetch((process.env.NODE_ENV === 'production' ? couchDbRemote : couchDbLocal) + '/events/_design/date/_view/by_date?include_docs=true&startkey="' + today + '"&endkey="' + fiveYearsFromNow + '"')
+    fetch((process.env.NODE_ENV === 'production' ? couchDbRemote : couchDbLocal) + '/events/_all_docs?include_docs=true')
       .then((response) => {
         return response.json();
       })

--- a/src/server/api/routes.js
+++ b/src/server/api/routes.js
@@ -1,5 +1,11 @@
 import { couchDbLocal, couchDbRemote } from '../../shared/config';
 
+// Using old school require because of https://github.com/moment/moment/issues/2608
+const moment = require('moment');
+
+const today = moment().toISOString();
+const fiveYearsFromNow = moment().add(5, 'years').toISOString();
+
 export default class Routes {
   constructor (workable) {
     this.workable = workable;
@@ -14,7 +20,7 @@ export default class Routes {
   };
 
   getEvents = (req, res) => {
-    fetch((process.env.NODE_ENV === 'production' ? couchDbRemote : couchDbLocal) + '/events/_all_docs?include_docs=true')
+    fetch((process.env.NODE_ENV === 'production' ? couchDbRemote : couchDbLocal) + '/events/_design/date/_view/by_date?include_docs=true&startkey="' + today + '"&endkey="' + fiveYearsFromNow + '"')
       .then((response) => {
         return response.json();
       })

--- a/src/server/api/routes.js
+++ b/src/server/api/routes.js
@@ -19,7 +19,10 @@ export default class Routes {
         return response.json();
       })
       .then((events) => {
-        res.send({list: events.rows.reverse()});
+        res.send({list: events.rows.sort(function (a, b) {
+          // also sort all events by date
+          return new Date(b.doc.datetime.iso) - new Date(a.doc.datetime.iso);
+        })});
       })
       .catch((err) => {
         res.status(err.status).send(err.message);

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -1,0 +1,86 @@
+// Display list of events
+// You can request only displaying events of past or future
+// with the `timeline` prop
+
+import React, { Component } from 'react';
+import styles from './style.css';
+
+import EventImage from '../event-image';
+import { imageAssetsEndpoint } from '../../config';
+import DateBubble from '../date-bubble';
+import HR from '../hr';
+import { Grid, Cell } from '../grid';
+import classNames from 'classnames';
+import icons from '../icons/style.css';
+
+export default class EventsList extends Component {
+  static propTypes = {
+    events: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    timeline: React.PropTypes.oneOf(['past', 'future'])
+  };
+
+  render () {
+    const today = new Date();
+    return (
+      <ul className={styles.eventsList}>
+        {
+          this.props.events.map((event) => {
+            const eventDate = new Date(event.doc.datetime.iso);
+            if (this.props.timeline === 'past' ?  eventDate < today : eventDate > today) {
+              const eventHref = `${event.doc.datetime.year}/${event.doc.datetime.month}/${event.doc.datetime.date}/${event.doc.slug}`;
+
+              return (
+                <li key={`event_${event.id}`} className={styles.eventItem}>
+                  <Grid fit={false}>
+                    <Cell size={1} breakOn="mobile">
+                      <HR color="grey" customClassName={styles.mobileHorizontalLine} />
+                      <DateBubble
+                          date={event.doc.datetime.date}
+                          month={event.doc.datetime.monthSym}
+                          year={event.doc.datetime.year}
+                      />
+                    </Cell>
+                    <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">
+                      <EventImage imgPath={ imageAssetsEndpoint + event.doc.attributes.featureImageFilename } href={eventHref} />
+                    </Cell>
+                    <Cell size={11} breakOn="mobile">
+                      <HR color="grey" customClassName={styles.wideHorizontalLine} />
+                      <Grid fit={false}>
+                        <Cell size={8} key='event_description' breakOn="mobileS">
+                          <a className={styles.eventTitleLink} href={eventHref}>
+                            <h2 className={styles.eventTitle}>
+                              {event.doc.attributes.title}
+                            </h2>
+                            <span className={classNames(
+                              {
+                                [styles.arrow]: true,
+                                [icons.sketchArrowRight]: true
+                              })}
+                            />
+                          </a>
+                          <div className={styles.eventDescription}>
+                            {event.doc.attributes.strapline}
+                          </div>
+                          <a href="#" className={styles.fullDetailsLink}>
+                              <span>For full details please visit</span>
+                              <span className={classNames({
+                                [icons.sketchExternalLink]: true,
+                                [styles.externalLinkIcon]: true
+                              })}
+                              />
+                          </a>
+                        </Cell>
+                        <Cell size={4} key='event_picture' breakOn="mobileS" hideOn="mobileS">
+                          <EventImage imgPath={ imageAssetsEndpoint + event.doc.attributes.featureImageFilename } href="#" />
+                        </Cell>
+                      </Grid>
+                    </Cell>
+                  </Grid>
+                </li>
+                );
+            }})
+        }
+      </ul>
+    );
+  }
+}

--- a/src/shared/components/events-list/style.css
+++ b/src/shared/components/events-list/style.css
@@ -1,0 +1,65 @@
+@value mobile from "../variables/breakpoints.css";
+
+.eventsList {
+  font-size: 1em;
+}
+
+.eventItem {
+  position: relative;
+  list-style-type: none;
+}
+
+.eventTitleLink {
+  text-decoration: none;
+}
+
+.eventTitle {
+  composes: h2 from "../../components/typography/style.css";
+  font-size: 1.6em;
+  text-decoration: none;
+  display: inline;
+  margin: 0 0 20px 0;
+}
+
+.eventTitle:hover, .eventTitle:active, .eventTitle:focus {
+  color: #be1414;
+}
+
+.arrow {
+  font-size: 1.2em;
+  color: black;
+}
+
+.fullDetailsLink {
+  composes: aBold from "../../components/typography/style.css";
+  color: black;
+  display: block;
+  text-decoration: none;
+  margin-top: 0.8em;
+  position: relative;
+}
+
+.eventDescription {
+  margin-top: 10px;
+}
+
+.externalLinkIcon {
+  font-size: 1em;
+  color: #be1414;
+  position: absolute;
+}
+
+.mobileHorizontalLine {
+  display: none;
+  margin: 1.5em 0 0 0;
+}
+
+@media mobile {
+  .wideHorizontalLine {
+    display: none;
+  }
+
+  .mobileHorizontalLine {
+    display: block;
+  }
+}

--- a/src/shared/containers/events/index.js
+++ b/src/shared/containers/events/index.js
@@ -3,16 +3,10 @@ import React, { Component } from 'react';
 import { fetchEvents } from '../../actions/events';
 import Section from '../../components/section';
 import styles from './style.css';
-import icons from '../../components/icons/style.css';
 import fetch from '../../util/fetch-proxy';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 
-import HR from '../../components/hr';
-import { Grid, Cell } from '../../components/grid';
-import DateBubble from '../../components/date-bubble';
-import EventImage from '../../components/event-image';
-import { imageAssetsEndpoint } from '../../config';
+import EventsList from '../../components/events-list';
 
 export class Events extends Component {
   static fetchData = fetchEvents(fetch());
@@ -23,63 +17,10 @@ export class Events extends Component {
         <Section>
           <Container>
             <h1 className={styles.h1}>Events</h1>
-            <ul className={styles.eventsList}>
-            {
-              this.props.events.map((event) => {
-                const eventHref = `${event.doc.datetime.year}/${event.doc.datetime.month}/${event.doc.datetime.date}/${event.doc.slug}`;
-
-                return (
-                  <li key={`event_${event.id}`} className={styles.eventItem}>
-                    <Grid fit={false}>
-                      <Cell size={1} breakOn="mobile">
-                        <HR color="grey" customClassName={styles.mobileHorizontalLine} />
-                        <DateBubble
-                            date={event.doc.datetime.date}
-                            month={event.doc.datetime.monthSym}
-                            year={event.doc.datetime.year}
-                        />
-                      </Cell>
-                      <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">
-                        <EventImage imgPath={ imageAssetsEndpoint + event.doc.attributes.featureImageFilename } href={eventHref} />
-                      </Cell>
-                      <Cell size={11} breakOn="mobile">
-                        <HR color="grey" customClassName={styles.wideHorizontalLine} />
-                        <Grid fit={false}>
-                          <Cell size={8} key='event_description' breakOn="mobileS">
-                            <a className={styles.eventTitleLink} href={eventHref}>
-                              <h2 className={styles.eventTitle}>
-                                {event.doc.attributes.title}
-                              </h2>
-                              <span className={classNames(
-                                {
-                                  [styles.arrow]: true,
-                                  [icons.sketchArrowRight]: true
-                                })}
-                              />
-                            </a>
-                            <div className={styles.eventDescription}>
-                              {event.doc.attributes.strapline}
-                            </div>
-                            <a href="#" className={styles.fullDetailsLink}>
-                                <span>For full details please visit</span>
-                                <span className={classNames({
-                                  [icons.sketchExternalLink]: true,
-                                  [styles.externalLinkIcon]: true
-                                })}
-                                />
-                            </a>
-                          </Cell>
-                          <Cell size={4} key='event_picture' breakOn="mobileS" hideOn="mobileS">
-                            <EventImage imgPath={ imageAssetsEndpoint + event.doc.attributes.featureImageFilename } href="#" />
-                          </Cell>
-                        </Grid>
-                      </Cell>
-                    </Grid>
-                  </li>
-                  );
-              })
-            }
-            </ul>
+            <h2>Upcoming events</h2>
+            <EventsList events={this.props.events} timeline="future" />
+            <h2 className={styles.pastEventsTitle}>Past events</h2>
+            <EventsList events={this.props.events} timeline="past" />
           </Container>
         </Section>
       </div>

--- a/src/shared/containers/events/style.css
+++ b/src/shared/containers/events/style.css
@@ -1,70 +1,8 @@
-@value mobile from "../../components/variables/breakpoints.css";
-
 .h1 {
   composes: h1 from "../../components/typography/style.css";
   text-align: center;
 }
 
-.eventsList {
-  font-size: 1em;
-}
-
-.eventItem {
-  position: relative;
-  list-style-type: none;
-}
-
-.eventTitleLink {
-  text-decoration: none;
-}
-
-.eventTitle {
-  composes: h2 from "../../components/typography/style.css";
-  font-size: 1.6em;
-  text-decoration: none;
-  display: inline;
-  margin: 0 0 20px 0;
-}
-
-.eventTitle:hover, .eventTitle:active, .eventTitle:focus {
-  color: #be1414;
-}
-
-.arrow {
-  font-size: 1.2em;
-  color: black;
-}
-
-.fullDetailsLink {
-  composes: aBold from "../../components/typography/style.css";
-  color: black;
-  display: block;
-  text-decoration: none;
-  margin-top: 0.8em;
-  position: relative;
-}
-
-.eventDescription {
-  margin-top: 10px;
-}
-
-.externalLinkIcon {
-  font-size: 1em;
-  color: #be1414;
-  position: absolute;
-}
-
-.mobileHorizontalLine {
-  display: none;
-  margin: 1.5em 0 0 0;
-}
-
-@media mobile {
-  .wideHorizontalLine {
-    display: none;
-  }
-
-  .mobileHorizontalLine {
-    display: block;
-  }
+.pastEventsTitle {
+  margin-top: 50px;
 }


### PR DESCRIPTION
![6GY01XQBkf3lS](https://camo.githubusercontent.com/11df7fc42a7ef73b7324c7510b5dbfa7a82a149a/68747470733a2f2f6d65646961332e67697068792e636f6d2f6d656469612f36475930315851426b66336c532f67697068792e676966>)

It's a nice UX improvement to have all events separated in upcoming and past events. We can even do this dynamically now.

- [x] Display future events in separate section
- [x] Display past events in separate section
- [x] Sorting events by date