### PR TITLE
Fix for #136 Mobile events landing: wrap text so that icons grouped

### DIFF
--- a/src/shared/components/event-links-list/index.js
+++ b/src/shared/components/event-links-list/index.js
@@ -15,7 +15,7 @@ export default class EventLinksList extends Component {
   render () {
     if (this.props.linkList.length > 0) {
       return (
-        <div>
+        <div className={styles.eventLinkList}>
           {
             this.props.linkList.map((eventLink) => {
               return (

--- a/src/shared/components/event-links-list/style.css
+++ b/src/shared/components/event-links-list/style.css
@@ -1,3 +1,8 @@
+.eventLinkList {
+  width: 100%;
+  float: left;
+}
+
 .fullDetailsLink {
   composes: aBold from "../../components/typography/style.css";
   color: black;
@@ -6,10 +11,16 @@
   margin-top: 0.8em;
   position: relative;
   text-decoration: none;
+  float: left;
+}
+
+.fullDetailsLink span {
+  display: inline;
 }
 
 .externalLinkIcon {
   font-size: 1em;
   color: #be1414;
   margin-bottom: 3px;
+  padding-left: 5px;
 }

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -99,14 +99,16 @@ export default class EventsList extends Component {
                           <Cell size={8} key='event_description' breakOn="mobileS">
                             <a className={styles.eventTitleLink} href={eventHref(event)}>
                               <h2 className={styles.eventTitle}>
-                                {event.doc.attributes.title}
+                                <span>
+                                  {event.doc.attributes.title}
+                                </span>
+                                <span className={classNames(
+                                  {
+                                    [styles.arrow]: true,
+                                    [icons.sketchArrowRight]: true
+                                  })}
+                                />
                               </h2>
-                              <span className={classNames(
-                                {
-                                  [styles.arrow]: true,
-                                  [icons.sketchArrowRight]: true
-                                })}
-                              />
                             </a>
                             <div className={styles.eventDescription}>
                               {event.doc.attributes.strapline}

--- a/src/shared/components/events-list/style.css
+++ b/src/shared/components/events-list/style.css
@@ -10,6 +10,10 @@
   text-align: center;
 }
 
+.eventsListTimelineSection h2.eventTitle {
+  text-align: left;
+}
+
 .eventsList {
   font-size: 1em;
   margin-top: 0;
@@ -30,6 +34,11 @@
   text-decoration: none;
   display: inline;
   margin: 0 0 20px 0;
+  float: left;
+}
+
+.eventTitle span {
+  display: inline;
 }
 
 .eventTitle:hover, .eventTitle:active, .eventTitle:focus {
@@ -37,12 +46,13 @@
 }
 
 .arrow {
-  font-size: 1.2em;
   color: red;
+  padding-left: 5px;
 }
 
 .eventDescription {
   margin-top: 10px;
+  float: left;
 }
 
 .mobileHorizontalLine {


### PR DESCRIPTION
![giphy 2](https://cloud.githubusercontent.com/assets/487468/15575842/d8eeb008-234c-11e6-8bcf-a9752b9da9fb.gif)
