### PR TITLE
fixed incorrect path to couchdb event import script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "build/server",
   "scripts": {
     "build": "npm run clean && webpack --progress",
-    "populate": "source .env && node utils/import-events-to-couchdb.js",
+    "populate": "source .env && node scripts/import-events-to-couchdb.js",
     "clean": "rimraf build",
     "lint": "eslint --cache .",
     "local": "NODE_ENV=development HOT=true node server.dev.js",


### PR DESCRIPTION
During setup there was an issue running the "populate" npm script caused by an incorrect folder name.