### PR TITLE
Fix for #145 - Refining event categorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "md-to-couch": "0.3.0",
+    "md-to-couch": "0.5.0",
     "mocha": "^2.4.5",
     "node-hook": "^0.2.0",
     "nodemon": "1.8.1",

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -28,9 +28,11 @@ export default class EventsList extends Component {
 
     let yesterday = new Date();
     yesterday.setDate(today.getDate() - 1);
+    yesterday.setHours(23, 59, 59);
 
     let tomorrow = new Date();
     tomorrow.setDate(today.getDate() + 1);
+    tomorrow.setHours(0, 0, 0);
 
     let relevantEvents = this.props.events.filter(function (event)
     {


### PR DESCRIPTION
Being more specific about date and time when filtering events
into Today, Upcoming and Past events

Fix for #145 