### PR TITLE
Add badger brain host environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ app:
   environment:
     - WORKABLE_KEY
     - NEWRELIC_LICENSE
+    - BADGER_BRAIN_HOST
 proxy:
   image: redbadger/website-next-proxy
   ports:


### PR DESCRIPTION
![giphy](https://media.giphy.com/media/GqDnImZ3UdJhS/giphy.gif)

### Pre-flight checklist

- [ ] Tests
- [x] Gif added

added badger brain host env var to our docker compose - this has also been added in circleci and should fix the issue with the events page on staging