### PR TITLE
fix layout in top of join us page

### DIFF
--- a/src/shared/containers/join-us/index.js
+++ b/src/shared/containers/join-us/index.js
@@ -111,11 +111,11 @@ export default class JoinUs extends Component {
         <Section>
           <Container>
             <ComponentRenderer data={titles} />
-            <Grid fit>
-              <Cell>
+            <Grid>
+              <Cell size='6'>
                 <ComponentRenderer data={join} />
               </Cell>
-              <Cell>
+              <Cell size='6'>
                 <Video id="110925126" type="vimeo" />
               </Cell>
             </Grid>


### PR DESCRIPTION
![](http://i.imgur.com/pHMII3A.gif)

the first section on the join-us page wasn't displaying nicely on mobile...  this fixes it.  