### PR TITLE
Fix for #116 Upcoming section link hover color

### DIFF
--- a/src/shared/components/events-side-list/style.css
+++ b/src/shared/components/events-side-list/style.css
@@ -1,5 +1,6 @@
 @value black from '../variables/colors.css';
 @value lightGrey2 from '../variables/colors.css';
+@value grey from '../variables/colors.css';
 
 .eventsSideList {
   font-size: 0.875em;
@@ -25,4 +26,8 @@
 .eventsSideList a {
   text-decoration: none;
   color: black;
+}
+
+.eventsSideList a:hover {
+  color: grey;
 }


### PR DESCRIPTION
![tumblr_inline_o91qsbh6pq1raprkq_500](https://cloud.githubusercontent.com/assets/487468/16311234/a3d03a3c-3967-11e6-9549-19922fa4eea5.gif)

Fix for #166 - Hover color on Upcoming events links list.

### Pre-flight checklist

- [x] Gif added


