### PR TITLE
Adding New Relic app config for staging and prod

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -10,7 +10,7 @@ exports.config = {
   /**
    * Array of application names.
    */
-  app_name: ['Red Badger Website'],
+  app_name: process.env.APP_ENV === 'production' ? ['[LIVE] Red Badger Website'] : ['[STAGING] Red Badger Website'],
   /**
    * Your New Relic license key.
    */


### PR DESCRIPTION
This change should separate monitoring on New Relic to staging and prod environments.



