### PR TITLE
Date-fns for calculating event position

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "body-parser": "^1.15.1",
     "chalk": "^1.1.1",
     "classnames": "^2.2.3",
+    "date-fns": "^1.3.0",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "express-prismic": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "karma-webpack": "^1.7.0",
     "md-to-couch": "0.5.0",
     "mocha": "^2.4.5",
+    "mockdate": "^1.0.4",
     "node-hook": "^0.2.0",
     "nodemon": "1.8.1",
     "nsp": "^2.2.0",

--- a/src/shared/util/split-events.js
+++ b/src/shared/util/split-events.js
@@ -1,23 +1,16 @@
+import dateFns from 'date-fns';
 
 export function splitEvents(events, timeline, { reverse = false } = {}) {
-  const today = new Date();
-
-  const yesterday = new Date();
-  yesterday.setDate(today.getDate() - 1);
-  yesterday.setHours(23, 59, 59);
-
-  const tomorrow = new Date();
-  tomorrow.setDate(today.getDate() + 1);
-  tomorrow.setHours(0, 0, 0);
-
   let relevantEvents = events.filter(event => {
-    const d = new Date(event.datetime.iso);
-    if (timeline === 'today') {
-      return (d.toDateString() === today.toDateString());
-    } else if (timeline === 'past') {
-      return (d < yesterday);
+    const d = dateFns.parse(event.datetime.iso);
+    switch (timeline) {
+      case 'today':
+        return dateFns.isToday(d);
+      case 'past':
+        return (dateFns.isPast(d) && !dateFns.isToday(d));
+      default:
+        return (dateFns.isFuture(d) && !dateFns.isToday(d));
     }
-    return (d > tomorrow);
   }, this);
 
   if (relevantEvents.length > 1 && reverse === true) {

--- a/src/shared/util/split-events.spec.js
+++ b/src/shared/util/split-events.spec.js
@@ -3,6 +3,18 @@ import { expect } from 'chai';
 
 const currentDate = new Date();
 
+const laterToday = new Date();
+
+// We need this, but this test will
+// fail if you run this after 23:00
+laterToday.setHours(currentDate.getHours() + 1);
+
+const earlierToday = new Date();
+
+// We need this, but this test will
+// fail if you run this before 01:00am
+earlierToday.setHours(currentDate.getHours() - 1);
+
 const futureDate = new Date();
 futureDate.setDate(futureDate.getDate() + 5);
 
@@ -32,6 +44,18 @@ const testevents = [
     id: 'today-event-2',
     datetime: {
       iso: currentDate,
+    },
+  },
+  {
+    id: 'later-today-event',
+    datetime: {
+      iso: laterToday,
+    },
+  },
+  {
+    id: 'earlier-today-event',
+    datetime: {
+      iso: earlierToday,
     },
   },
   {
@@ -68,9 +92,11 @@ describe('SplitEvents', () => {
   it('returns todays events', () => {
     const timeline = 'today';
     const returnedEvents = splitEvents(testevents, timeline);
-    expect(returnedEvents.length).to.equal(2);
+    expect(returnedEvents.length).to.equal(4);
     expect(returnedEvents[0].id).to.equal('today-event-1');
     expect(returnedEvents[1].id).to.equal('today-event-2');
+    expect(returnedEvents[2].id).to.equal('later-today-event');
+    expect(returnedEvents[3].id).to.equal('earlier-today-event');
   });
 
   it('returns events in reverse order when specified', () => {

--- a/src/shared/util/split-events.spec.js
+++ b/src/shared/util/split-events.spec.js
@@ -2,74 +2,82 @@ import { splitEvents } from './split-events';
 import { expect } from 'chai';
 import * as MockDate from 'mockdate';
 
-MockDate.set('Thu Jun 23 2016 14:10:56 GMT+0100 (BST)');
-
-const currentDate = new Date();
-
-const laterToday = new Date();
-laterToday.setHours(currentDate.getHours() + 1);
-
-const earlierToday = new Date();
-earlierToday.setHours(currentDate.getHours() - 1);
-
-const futureDate = new Date();
-futureDate.setDate(futureDate.getDate() + 5);
-
-const previousDate = new Date();
-previousDate.setDate(previousDate.getDate() - 5);
-
-const testevents = [
-  {
-    id: 'past-event-1',
-    datetime: {
-      iso: previousDate,
-    },
-  },
-  {
-    id: 'past-event-2',
-    datetime: {
-      iso: previousDate,
-    },
-  },
-  {
-    id: 'today-event-1',
-    datetime: {
-      iso: currentDate,
-    },
-  },
-  {
-    id: 'today-event-2',
-    datetime: {
-      iso: currentDate,
-    },
-  },
-  {
-    id: 'later-today-event',
-    datetime: {
-      iso: laterToday,
-    },
-  },
-  {
-    id: 'earlier-today-event',
-    datetime: {
-      iso: earlierToday,
-    },
-  },
-  {
-    id: 'future-event-1',
-    datetime: {
-      iso: futureDate,
-    },
-  },
-  {
-    id: 'future-event-2',
-    datetime: {
-      iso: futureDate,
-    },
-  },
-];
+let testevents = [];
 
 describe('SplitEvents', () => {
+  beforeEach(() => {
+    MockDate.set('Thu Jun 23 2016 14:10:56 GMT+0100 (BST)');
+
+    const currentDate = new Date();
+
+    const laterToday = new Date();
+    laterToday.setHours(currentDate.getHours() + 1);
+
+    const earlierToday = new Date();
+    earlierToday.setHours(currentDate.getHours() - 1);
+
+    const futureDate = new Date();
+    futureDate.setDate(futureDate.getDate() + 5);
+
+    const previousDate = new Date();
+    previousDate.setDate(previousDate.getDate() - 5);
+
+    testevents = [
+      {
+        id: 'past-event-1',
+        datetime: {
+          iso: previousDate,
+        },
+      },
+      {
+        id: 'past-event-2',
+        datetime: {
+          iso: previousDate,
+        },
+      },
+      {
+        id: 'today-event-1',
+        datetime: {
+          iso: currentDate,
+        },
+      },
+      {
+        id: 'today-event-2',
+        datetime: {
+          iso: currentDate,
+        },
+      },
+      {
+        id: 'later-today-event',
+        datetime: {
+          iso: laterToday,
+        },
+      },
+      {
+        id: 'earlier-today-event',
+        datetime: {
+          iso: earlierToday,
+        },
+      },
+      {
+        id: 'future-event-1',
+        datetime: {
+          iso: futureDate,
+        },
+      },
+      {
+        id: 'future-event-2',
+        datetime: {
+          iso: futureDate,
+        },
+      },
+    ];
+  });
+
+  afterEach(() => {
+    MockDate.reset();
+  });
+
   it('returns future events', () => {
     const timeline = 'future';
     const returnedEvents = splitEvents(testevents, timeline);

--- a/src/shared/util/split-events.spec.js
+++ b/src/shared/util/split-events.spec.js
@@ -1,18 +1,15 @@
 import { splitEvents } from './split-events';
 import { expect } from 'chai';
+import * as MockDate from 'mockdate';
+
+MockDate.set('Thu Jun 23 2016 14:10:56 GMT+0100 (BST)');
 
 const currentDate = new Date();
 
 const laterToday = new Date();
-
-// We need this, but this test will
-// fail if you run this after 23:00
 laterToday.setHours(currentDate.getHours() + 1);
 
 const earlierToday = new Date();
-
-// We need this, but this test will
-// fail if you run this before 01:00am
 earlierToday.setHours(currentDate.getHours() - 1);
 
 const futureDate = new Date();


### PR DESCRIPTION
![giphy 6](https://cloud.githubusercontent.com/assets/487468/16337239/ae4fee36-3a0b-11e6-80d6-b0db07386459.gif)

This fixes #172 

Safari failed to construct Date object from the ISO string, hence replacing Date() with more reliable `date-fns` functionality.

Added extra tests too for capturing edge cases.

### Pre-flight checklist

- [x] Tests
- [x] Gif added