### PR TITLE
Fix for #173 case sensitive URL for event slugs

### DIFF
--- a/src/shared/actions/events/event.js
+++ b/src/shared/actions/events/event.js
@@ -44,7 +44,7 @@ export const fetchEvent = (fetch) => (
     return fetchEvents(fetch)(dispatch, getState)
       .then(() => { // eslint-disable-line consistent-return
         const event = getState().events.find(j =>
-          j.slug === nextState.params.slug
+          j.slug.toUpperCase() === nextState.params.slug.toUpperCase()
         );
         if (event) {
           dispatch(fetchSuccessful(event));

--- a/src/shared/actions/events/event.spec.js
+++ b/src/shared/actions/events/event.spec.js
@@ -66,7 +66,9 @@ describe('event actions', () => {
           ],
         };
         nextState = {
-          params: {},
+          params: {
+            slug: 'unknown-event',
+          },
         };
         getState = () => state;
       });


### PR DESCRIPTION
![giphy](https://cloud.githubusercontent.com/assets/487468/16413335/3f1d33e0-3d29-11e6-8ac7-8b85a6faf2c5.gif)

Now full URL for events is case insensitive

### Pre-flight checklist

- [x] Tests
- [x] Gif added


