### PR TITLE
Multiday events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,371 @@
+# Change Log
+
+## [Unreleased](https://github.com/redbadger/website-next/tree/HEAD)
+
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.3.5...HEAD)
+
+**Merged pull requests:**
+
+- Fix for \#195 link to the React London conf page [\#196](https://github.com/redbadger/website-next/pull/196) ([asavin](https://github.com/asavin))
+
+## [v0.3.5](https://github.com/redbadger/website-next/tree/v0.3.5) (2016-07-07)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.3.4...v0.3.5)
+
+**Merged pull requests:**
+
+- Adding Google Analytics to track client activity [\#193](https://github.com/redbadger/website-next/pull/193) ([asavin](https://github.com/asavin))
+
+## [v0.3.4](https://github.com/redbadger/website-next/tree/v0.3.4) (2016-07-01)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.3.3...v0.3.4)
+
+**Merged pull requests:**
+
+- Fixed Prismic Previews... finally [\#187](https://github.com/redbadger/website-next/pull/187) ([chris-goodchild](https://github.com/chris-goodchild))
+
+## [v0.3.3](https://github.com/redbadger/website-next/tree/v0.3.3) (2016-07-01)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.3.2...v0.3.3)
+
+**Fixed bugs:**
+
+- URL routing case sensitive [\#173](https://github.com/redbadger/website-next/issues/173)
+
+**Merged pull requests:**
+
+- Update Prismic configuration [\#185](https://github.com/redbadger/website-next/pull/185) ([chris-goodchild](https://github.com/chris-goodchild))
+- Apply tags feedback [\#184](https://github.com/redbadger/website-next/pull/184) ([chris-goodchild](https://github.com/chris-goodchild))
+- Applied temporary fix - see issue \#182 [\#183](https://github.com/redbadger/website-next/pull/183) ([chris-goodchild](https://github.com/chris-goodchild))
+- Add unpublished preview [\#181](https://github.com/redbadger/website-next/pull/181) ([chris-goodchild](https://github.com/chris-goodchild))
+- Add event tags [\#175](https://github.com/redbadger/website-next/pull/175) ([chris-goodchild](https://github.com/chris-goodchild))
+
+## [v0.3.2](https://github.com/redbadger/website-next/tree/v0.3.2) (2016-06-28)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.3.1...v0.3.2)
+
+**Fixed bugs:**
+
+- Safari: event body markup rendered as text [\#174](https://github.com/redbadger/website-next/issues/174)
+- Event details: Change 'Upcoming' section text hover to be lighter grey [\#166](https://github.com/redbadger/website-next/issues/166)
+
+**Merged pull requests:**
+
+- Revert "Add Prismic preview token" [\#180](https://github.com/redbadger/website-next/pull/180) ([asavin](https://github.com/asavin))
+- Add Prismic preview token [\#179](https://github.com/redbadger/website-next/pull/179) ([chris-goodchild](https://github.com/chris-goodchild))
+- Fix for \#173 case sensitive URL for event slugs [\#178](https://github.com/redbadger/website-next/pull/178) ([asavin](https://github.com/asavin))
+
+## [v0.3.1](https://github.com/redbadger/website-next/tree/v0.3.1) (2016-06-24)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.3.0...v0.3.1)
+
+**Fixed bugs:**
+
+- Events list on Safari browser is hidden [\#172](https://github.com/redbadger/website-next/issues/172)
+- Jobs page doesn't look great on mobile sized viewport [\#159](https://github.com/redbadger/website-next/issues/159)
+- Event article: \#\#\# appear in article text [\#134](https://github.com/redbadger/website-next/issues/134)
+
+**Merged pull requests:**
+
+- Date-fns for calculating event position [\#176](https://github.com/redbadger/website-next/pull/176) ([asavin](https://github.com/asavin))
+- Adding New Relic app config for staging and prod [\#171](https://github.com/redbadger/website-next/pull/171) ([asavin](https://github.com/asavin))
+- Fix for \#116 Upcoming section link hover color [\#170](https://github.com/redbadger/website-next/pull/170) ([asavin](https://github.com/asavin))
+- Implement document preview \(published docs only\) [\#169](https://github.com/redbadger/website-next/pull/169) ([chris-goodchild](https://github.com/chris-goodchild))
+- fix layout in top of join us page [\#168](https://github.com/redbadger/website-next/pull/168) ([tmerlet](https://github.com/tmerlet))
+- fix for "Jobs page doesn't look great on mobile sized viewport" [\#167](https://github.com/redbadger/website-next/pull/167) ([tmerlet](https://github.com/tmerlet))
+
+## [v0.3.0](https://github.com/redbadger/website-next/tree/v0.3.0) (2016-06-22)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.2.5...v0.3.0)
+
+**Implemented enhancements:**
+
+- Remove react warnings/errors [\#68](https://github.com/redbadger/website-next/issues/68)
+
+**Fixed bugs:**
+
+- Remove react warnings/errors [\#68](https://github.com/redbadger/website-next/issues/68)
+
+**Closed issues:**
+
+- Remove duplicate query string dependencies [\#158](https://github.com/redbadger/website-next/issues/158)
+
+**Merged pull requests:**
+
+- Add badger brain host environment variable [\#165](https://github.com/redbadger/website-next/pull/165) ([chris-goodchild](https://github.com/chris-goodchild))
+- Moving preview route above app routes [\#164](https://github.com/redbadger/website-next/pull/164) ([chris-goodchild](https://github.com/chris-goodchild))
+- appending '/api' to the apiEndPoint config option as per NodeSDK docs [\#163](https://github.com/redbadger/website-next/pull/163) ([chris-goodchild](https://github.com/chris-goodchild))
+- Removed duplicate dependencies [\#161](https://github.com/redbadger/website-next/pull/161) ([chris-goodchild](https://github.com/chris-goodchild))
+- Prismic Document Preview \(first pass\) [\#160](https://github.com/redbadger/website-next/pull/160) ([chris-goodchild](https://github.com/chris-goodchild))
+- Split events [\#157](https://github.com/redbadger/website-next/pull/157) ([tmerlet](https://github.com/tmerlet))
+- Fix console warnings [\#156](https://github.com/redbadger/website-next/pull/156) ([chris-goodchild](https://github.com/chris-goodchild))
+- Fixing lint errors [\#155](https://github.com/redbadger/website-next/pull/155) ([chris-goodchild](https://github.com/chris-goodchild))
+- Fix lint errors [\#153](https://github.com/redbadger/website-next/pull/153) ([chris-goodchild](https://github.com/chris-goodchild))
+- Querying Badger Brain for events data [\#152](https://github.com/redbadger/website-next/pull/152) ([asavin](https://github.com/asavin))
+- Linting and hooks [\#151](https://github.com/redbadger/website-next/pull/151) ([asavin](https://github.com/asavin))
+
+## [v0.2.5](https://github.com/redbadger/website-next/tree/v0.2.5) (2016-06-08)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.2.4...v0.2.5)
+
+**Merged pull requests:**
+
+- Making Cloudinary image src protocol agnostic [\#150](https://github.com/redbadger/website-next/pull/150) ([asavin](https://github.com/asavin))
+
+## [v0.2.4](https://github.com/redbadger/website-next/tree/v0.2.4) (2016-06-03)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.2.3...v0.2.4)
+
+**Merged pull requests:**
+
+- Admin interface for creating new events [\#116](https://github.com/redbadger/website-next/pull/116) ([asavin](https://github.com/asavin))
+
+## [v0.2.3](https://github.com/redbadger/website-next/tree/v0.2.3) (2016-06-01)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.2.2...v0.2.3)
+
+**Implemented enhancements:**
+
+- Update job content [\#70](https://github.com/redbadger/website-next/issues/70)
+
+**Fixed bugs:**
+
+- Tomorrow's events are hidden [\#145](https://github.com/redbadger/website-next/issues/145)
+- Mobile event article: Increase menu font size to match production [\#132](https://github.com/redbadger/website-next/issues/132)
+- Mobile event article: Increase 'Recent events' section font size to match production [\#131](https://github.com/redbadger/website-next/issues/131)
+
+**Closed issues:**
+
+- Markdown editors [\#20](https://github.com/redbadger/website-next/issues/20)
+
+**Merged pull requests:**
+
+- Responsive banner for events on React Conference [\#149](https://github.com/redbadger/website-next/pull/149) ([asavin](https://github.com/asavin))
+
+## [v0.2.2](https://github.com/redbadger/website-next/tree/v0.2.2) (2016-05-31)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.2.1...v0.2.2)
+
+**Merged pull requests:**
+
+- Fix for \#145 - Refining event categorization [\#148](https://github.com/redbadger/website-next/pull/148) ([asavin](https://github.com/asavin))
+- Fixed importing project env in local dev mode [\#144](https://github.com/redbadger/website-next/pull/144) ([sebflipper](https://github.com/sebflipper))
+
+## [v0.2.1](https://github.com/redbadger/website-next/tree/v0.2.1) (2016-05-27)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.2.0...v0.2.1)
+
+**Fixed bugs:**
+
+- Footer responsive layout while on events page [\#137](https://github.com/redbadger/website-next/issues/137)
+- Mobile events landing: wrap text so that icons grouped [\#136](https://github.com/redbadger/website-next/issues/136)
+
+**Merged pull requests:**
+
+- added missing unit tests for the event actions [\#143](https://github.com/redbadger/website-next/pull/143) ([chris-goodchild](https://github.com/chris-goodchild))
+- Enabling New Relic integration [\#142](https://github.com/redbadger/website-next/pull/142) ([asavin](https://github.com/asavin))
+- fixed incorrect path to couchdb event import script [\#141](https://github.com/redbadger/website-next/pull/141) ([chris-goodchild](https://github.com/chris-goodchild))
+
+## [v0.2.0](https://github.com/redbadger/website-next/tree/v0.2.0) (2016-05-26)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.1.6...v0.2.0)
+
+**Fixed bugs:**
+
+- Event article: Footer layout needs to wrap on mobile [\#130](https://github.com/redbadger/website-next/issues/130)
+- Mobile events landing page: Link icon misplaced [\#129](https://github.com/redbadger/website-next/issues/129)
+- Mobile events landing page: Reduce left margin to match right [\#128](https://github.com/redbadger/website-next/issues/128)
+- Event article page: 'More events' should change to red on hover over [\#126](https://github.com/redbadger/website-next/issues/126)
+- Event article page: Sub-heading should be bold [\#125](https://github.com/redbadger/website-next/issues/125)
+- Events landing page: 'More by' link icon incorrect + should open in same tab [\#124](https://github.com/redbadger/website-next/issues/124)
+- Events landing page: Event duplicated with different dates [\#122](https://github.com/redbadger/website-next/issues/122)
+- Events landing page: Reverse ordering of 'Upcoming events' [\#120](https://github.com/redbadger/website-next/issues/120)
+- Events landing page: Header arrow colour should be red [\#119](https://github.com/redbadger/website-next/issues/119)
+- Events landing page: Image links need updating [\#118](https://github.com/redbadger/website-next/issues/118)
+- Make sure all entities are rendered properly. [\#67](https://github.com/redbadger/website-next/issues/67)
+
+**Merged pull requests:**
+
+- Fix for \#137 Footer responsive layout [\#139](https://github.com/redbadger/website-next/pull/139) ([asavin](https://github.com/asavin))
+- Fix for \#136 Mobile events landing: wrap text so that icons grouped [\#138](https://github.com/redbadger/website-next/pull/138) ([asavin](https://github.com/asavin))
+- Centering events timeline titles, fixing responsive behaviour of footer [\#135](https://github.com/redbadger/website-next/pull/135) ([asavin](https://github.com/asavin))
+- Adding Helmet support for dynamic page titles [\#133](https://github.com/redbadger/website-next/pull/133) ([asavin](https://github.com/asavin))
+- Events pages UI fixes [\#127](https://github.com/redbadger/website-next/pull/127) ([asavin](https://github.com/asavin))
+- Today events section [\#123](https://github.com/redbadger/website-next/pull/123) ([asavin](https://github.com/asavin))
+- Recent events component and styles [\#121](https://github.com/redbadger/website-next/pull/121) ([asavin](https://github.com/asavin))
+- Events page display past and upcoming events in 2 separate sections [\#117](https://github.com/redbadger/website-next/pull/117) ([asavin](https://github.com/asavin))
+- Event page [\#115](https://github.com/redbadger/website-next/pull/115) ([asavin](https://github.com/asavin))
+- DB authentication with user credentials [\#114](https://github.com/redbadger/website-next/pull/114) ([asavin](https://github.com/asavin))
+- Events page WIP [\#113](https://github.com/redbadger/website-next/pull/113) ([asavin](https://github.com/asavin))
+- Events page initial work [\#112](https://github.com/redbadger/website-next/pull/112) ([asavin](https://github.com/asavin))
+
+## [v0.1.6](https://github.com/redbadger/website-next/tree/v0.1.6) (2016-05-03)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.1.5...v0.1.6)
+
+**Merged pull requests:**
+
+- Footer Subscribe copy fix [\#111](https://github.com/redbadger/website-next/pull/111) ([asavin](https://github.com/asavin))
+
+## [v0.1.5](https://github.com/redbadger/website-next/tree/v0.1.5) (2016-04-29)
+[Full Changelog](https://github.com/redbadger/website-next/compare/0.1.5...v0.1.5)
+
+## [0.1.5](https://github.com/redbadger/website-next/tree/0.1.5) (2016-04-29)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.1.4...0.1.5)
+
+**Merged pull requests:**
+
+- Unescaping HTML content fetched from Workable API [\#110](https://github.com/redbadger/website-next/pull/110) ([asavin](https://github.com/asavin))
+
+## [v0.1.4](https://github.com/redbadger/website-next/tree/v0.1.4) (2016-02-15)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.1.3...v0.1.4)
+
+**Merged pull requests:**
+
+- Edit copy for join us decription [\#109](https://github.com/redbadger/website-next/pull/109) ([krigar](https://github.com/krigar))
+
+## [v0.1.3](https://github.com/redbadger/website-next/tree/v0.1.3) (2016-02-11)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.1.2...v0.1.3)
+
+**Merged pull requests:**
+
+- Same size footer as old site [\#108](https://github.com/redbadger/website-next/pull/108) ([krigar](https://github.com/krigar))
+- Proper max-width for nav bar [\#107](https://github.com/redbadger/website-next/pull/107) ([krigar](https://github.com/krigar))
+- Fix navigation on mobile not behaving like old site. [\#106](https://github.com/redbadger/website-next/pull/106) ([tabazevedo](https://github.com/tabazevedo))
+
+## [v0.1.2](https://github.com/redbadger/website-next/tree/v0.1.2) (2016-02-10)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.1.1...v0.1.2)
+
+**Implemented enhancements:**
+
+- 500 page [\#72](https://github.com/redbadger/website-next/issues/72)
+
+**Fixed bugs:**
+
+- Join us and Jobs page: The badger logo on when scrolled should link to homepage [\#101](https://github.com/redbadger/website-next/issues/101)
+- Join us page: vertical spacing between cards need to be smaller on mobile view [\#99](https://github.com/redbadger/website-next/issues/99)
+- Join us page: remove a space between ? and \* [\#98](https://github.com/redbadger/website-next/issues/98)
+- 404 should look like current one [\#71](https://github.com/redbadger/website-next/issues/71)
+- Page does not scroll to top when changing route client side [\#55](https://github.com/redbadger/website-next/issues/55)
+
+**Merged pull requests:**
+
+- Wrap for?\* string responsively [\#104](https://github.com/redbadger/website-next/pull/104) ([krigar](https://github.com/krigar))
+- Remove margin-top from notes [\#103](https://github.com/redbadger/website-next/pull/103) ([tabazevedo](https://github.com/tabazevedo))
+- Change badge to an anchor, and link to homepage [\#102](https://github.com/redbadger/website-next/pull/102) ([tabazevedo](https://github.com/tabazevedo))
+- Add production steps to webpack config [\#100](https://github.com/redbadger/website-next/pull/100) ([tabazevedo](https://github.com/tabazevedo))
+
+## [v0.1.1](https://github.com/redbadger/website-next/tree/v0.1.1) (2016-02-10)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.1.0...v0.1.1)
+
+**Fixed bugs:**
+
+- Job description page: gap between "see all vacancies" and "How to apply" box [\#93](https://github.com/redbadger/website-next/issues/93)
+
+**Closed issues:**
+
+- Footer: alignment and spacing issues [\#94](https://github.com/redbadger/website-next/issues/94)
+
+**Merged pull requests:**
+
+- Footer css tweak [\#97](https://github.com/redbadger/website-next/pull/97) ([krigar](https://github.com/krigar))
+- Add top margin for Apply note on small media [\#96](https://github.com/redbadger/website-next/pull/96) ([krigar](https://github.com/krigar))
+- Add window.scrollTo onUpdate [\#95](https://github.com/redbadger/website-next/pull/95) ([tabazevedo](https://github.com/tabazevedo))
+- Remove LFS [\#92](https://github.com/redbadger/website-next/pull/92) ([tabazevedo](https://github.com/tabazevedo))
+
+## [v0.1.0](https://github.com/redbadger/website-next/tree/v0.1.0) (2016-02-08)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.0.2...v0.1.0)
+
+**Implemented enhancements:**
+
+- 404 Page handling [\#81](https://github.com/redbadger/website-next/issues/81)
+- Async Behaviour [\#80](https://github.com/redbadger/website-next/issues/80)
+
+**Fixed bugs:**
+
+- 404 Page handling [\#81](https://github.com/redbadger/website-next/issues/81)
+
+**Closed issues:**
+
+- Mobile design for job detail page [\#75](https://github.com/redbadger/website-next/issues/75)
+
+**Merged pull requests:**
+
+- Fix lfs [\#91](https://github.com/redbadger/website-next/pull/91) ([tabazevedo](https://github.com/tabazevedo))
+- Use React for rendering markup templates server-side. [\#90](https://github.com/redbadger/website-next/pull/90) ([tabazevedo](https://github.com/tabazevedo))
+- Migrate to class syntax [\#89](https://github.com/redbadger/website-next/pull/89) ([tabazevedo](https://github.com/tabazevedo))
+- Design 404 page [\#76](https://github.com/redbadger/website-next/pull/76) ([lithin](https://github.com/lithin))
+
+## [v0.0.2](https://github.com/redbadger/website-next/tree/v0.0.2) (2016-02-05)
+[Full Changelog](https://github.com/redbadger/website-next/compare/v0.0.1...v0.0.2)
+
+**Merged pull requests:**
+
+- Config changes & code cleanup [\#88](https://github.com/redbadger/website-next/pull/88) ([tabazevedo](https://github.com/tabazevedo))
+- Routing updates [\#87](https://github.com/redbadger/website-next/pull/87) ([tabazevedo](https://github.com/tabazevedo))
+- Docker compose [\#86](https://github.com/redbadger/website-next/pull/86) ([krigar](https://github.com/krigar))
+- Fetch assets from /assets [\#85](https://github.com/redbadger/website-next/pull/85) ([krigar](https://github.com/krigar))
+- CircleCI testing [\#84](https://github.com/redbadger/website-next/pull/84) ([krigar](https://github.com/krigar))
+- Adjust apply now note on job detail page on mobile view [\#77](https://github.com/redbadger/website-next/pull/77) ([lithin](https://github.com/lithin))
+
+## [v0.0.1](https://github.com/redbadger/website-next/tree/v0.0.1) (2016-02-02)
+**Implemented enhancements:**
+
+- Optimise Babel for server and client [\#37](https://github.com/redbadger/website-next/issues/37)
+- Adjustable column sizes for grid [\#35](https://github.com/redbadger/website-next/issues/35)
+- Added initial Redux integration [\#41](https://github.com/redbadger/website-next/pull/41) ([sheepsteak](https://github.com/sheepsteak))
+- Turned on babel-loader caching [\#33](https://github.com/redbadger/website-next/pull/33) ([sheepsteak](https://github.com/sheepsteak))
+- Added ESLint caching and linting more files [\#32](https://github.com/redbadger/website-next/pull/32) ([sheepsteak](https://github.com/sheepsteak))
+- Added pre-push Git hook [\#12](https://github.com/redbadger/website-next/pull/12) ([sheepsteak](https://github.com/sheepsteak))
+
+**Fixed bugs:**
+
+- Fix width of job listing in different view port sizes [\#69](https://github.com/redbadger/website-next/issues/69)
+- Update content [\#66](https://github.com/redbadger/website-next/issues/66)
+- External links [\#65](https://github.com/redbadger/website-next/issues/65)
+
+**Closed issues:**
+
+- Server bundle is accessible from browser [\#26](https://github.com/redbadger/website-next/issues/26)
+- Create wrapped html components [\#24](https://github.com/redbadger/website-next/issues/24)
+- Make components stateless if possible [\#23](https://github.com/redbadger/website-next/issues/23)
+- Investigate isomorphic routing [\#10](https://github.com/redbadger/website-next/issues/10)
+- Replace wordpress shorthand tags with HTML [\#2](https://github.com/redbadger/website-next/issues/2)
+
+**Merged pull requests:**
+
+- Deploy version tags to production [\#82](https://github.com/redbadger/website-next/pull/82) ([krigar](https://github.com/krigar))
+- Node Security Advisory - 55 [\#79](https://github.com/redbadger/website-next/pull/79) ([krigar](https://github.com/krigar))
+- Fix external link to application [\#74](https://github.com/redbadger/website-next/pull/74) ([lithin](https://github.com/lithin))
+- Fix note in a grid to fit the column [\#73](https://github.com/redbadger/website-next/pull/73) ([lithin](https://github.com/lithin))
+- Docker deployment [\#64](https://github.com/redbadger/website-next/pull/64) ([krigar](https://github.com/krigar))
+- Add custom solution similar to masonry [\#63](https://github.com/redbadger/website-next/pull/63) ([lithin](https://github.com/lithin))
+- Change apply note copy, remove Workable subtitles in detail page [\#62](https://github.com/redbadger/website-next/pull/62) ([lithin](https://github.com/lithin))
+- Remove quiet flag from eb deploy [\#61](https://github.com/redbadger/website-next/pull/61) ([krigar](https://github.com/krigar))
+- Make the eb deploy command return immediately [\#60](https://github.com/redbadger/website-next/pull/60) ([krigar](https://github.com/krigar))
+- Elastic Beanstalk integration [\#59](https://github.com/redbadger/website-next/pull/59) ([krigar](https://github.com/krigar))
+- Add favioncs and apple touch icons [\#58](https://github.com/redbadger/website-next/pull/58) ([lithin](https://github.com/lithin))
+- Open new tab when clicking 'apply here' in note [\#57](https://github.com/redbadger/website-next/pull/57) ([krigar](https://github.com/krigar))
+- Add link to workable on job pages [\#56](https://github.com/redbadger/website-next/pull/56) ([krigar](https://github.com/krigar))
+- Job page [\#54](https://github.com/redbadger/website-next/pull/54) ([RGBboy](https://github.com/RGBboy))
+- Fix red color in job component; [\#53](https://github.com/redbadger/website-next/pull/53) ([RGBboy](https://github.com/RGBboy))
+- Add node security check to build [\#51](https://github.com/redbadger/website-next/pull/51) ([gregstewart](https://github.com/gregstewart))
+- Use the 'real' html-to-react library [\#48](https://github.com/redbadger/website-next/pull/48) ([lithin](https://github.com/lithin))
+- Add routing to client and server [\#47](https://github.com/redbadger/website-next/pull/47) ([lithin](https://github.com/lithin))
+- Stateless components [\#45](https://github.com/redbadger/website-next/pull/45) ([lithin](https://github.com/lithin))
+- Grid sizing [\#44](https://github.com/redbadger/website-next/pull/44) ([RGBboy](https://github.com/RGBboy))
+- Workable client [\#43](https://github.com/redbadger/website-next/pull/43) ([lithin](https://github.com/lithin))
+- Fix cross-browser issues [\#40](https://github.com/redbadger/website-next/pull/40) ([lithin](https://github.com/lithin))
+- Workable API Proxy [\#39](https://github.com/redbadger/website-next/pull/39) ([RGBboy](https://github.com/RGBboy))
+- Job listings html [\#38](https://github.com/redbadger/website-next/pull/38) ([lithin](https://github.com/lithin))
+- Added client Hot Module Reloading [\#36](https://github.com/redbadger/website-next/pull/36) ([sheepsteak](https://github.com/sheepsteak))
+- Job listings [\#34](https://github.com/redbadger/website-next/pull/34) ([lithin](https://github.com/lithin))
+- Add code coverage [\#31](https://github.com/redbadger/website-next/pull/31) ([RGBboy](https://github.com/RGBboy))
+- Component renderer [\#30](https://github.com/redbadger/website-next/pull/30) ([lithin](https://github.com/lithin))
+- Enable phantomjs karma [\#28](https://github.com/redbadger/website-next/pull/28) ([gregstewart](https://github.com/gregstewart))
+- Add badge a sticky nav [\#27](https://github.com/redbadger/website-next/pull/27) ([lithin](https://github.com/lithin))
+- Added `robots.txt` [\#25](https://github.com/redbadger/website-next/pull/25) ([sheepsteak](https://github.com/sheepsteak))
+- Set node version [\#22](https://github.com/redbadger/website-next/pull/22) ([gregstewart](https://github.com/gregstewart))
+- Deploying `master` to Heroku [\#21](https://github.com/redbadger/website-next/pull/21) ([sheepsteak](https://github.com/sheepsteak))
+- Static join us page [\#19](https://github.com/redbadger/website-next/pull/19) ([RGBboy](https://github.com/RGBboy))
+- Update babel presets to use stage-1; [\#18](https://github.com/redbadger/website-next/pull/18) ([RGBboy](https://github.com/RGBboy))
+- Karma [\#17](https://github.com/redbadger/website-next/pull/17) ([lithin](https://github.com/lithin))
+- Fix unit tests - mocha [\#16](https://github.com/redbadger/website-next/pull/16) ([lithin](https://github.com/lithin))
+- Added CircleCI support [\#15](https://github.com/redbadger/website-next/pull/15) ([sheepsteak](https://github.com/sheepsteak))
+- Set up unit tests [\#14](https://github.com/redbadger/website-next/pull/14) ([lithin](https://github.com/lithin))
+- Fix getting started instructions; [\#13](https://github.com/redbadger/website-next/pull/13) ([RGBboy](https://github.com/RGBboy))
+- Updates [\#7](https://github.com/redbadger/website-next/pull/7) ([tabazevedo](https://github.com/tabazevedo))
+- Update Relay, React and Router libs [\#6](https://github.com/redbadger/website-next/pull/6) ([romanschejbal](https://github.com/romanschejbal))
+- Post previews and improvements in post parsing [\#5](https://github.com/redbadger/website-next/pull/5) ([asavin](https://github.com/asavin))
+- Fix webpack styles reloading / render Jade Express templates [\#4](https://github.com/redbadger/website-next/pull/4) ([albertstill](https://github.com/albertstill))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,6 @@ test:
     - npm run lint
     - npm run security:check
     - npm run test:server
-    - npm run test:client -- --browsers PhantomJS
     - export APP_HOST=`ifconfig eth0 | grep -oP 'inet addr:\K\S+'` && COMPOSE_FILE=docker-compose-test.yml docker-compose up -d
     - npm run test:e2e
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "security:check": "./node_modules/.bin/nsp check",
     "start": "node build/server",
     "test": "npm run test:server && npm run security:check",
-    "test-full": "npm run test:server && npm run test:client && npm run security:check && npm run lint && npm run test:e2e",
-    "test:client": "karma start spec/karma.config.js",
+    "test-full": "npm run test:server && npm run security:check && npm run lint && npm run test:e2e",
     "test:e2e": "wdio spec/wdio.config.js",
     "test:server": "mocha --compilers js:babel-core/register --require spec/mocha-helper.js --recursive --reporter spec $(find src -name *spec.js)"
   },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "chai": "^3.5.0",
     "css-loader": "^0.23.1",
     "css-modules-require-hook": "^2.1.0",
+    "enzyme": "^2.4.1",
     "eslint": "^2.12.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.8.1",

--- a/spec/fixtures/events.js
+++ b/spec/fixtures/events.js
@@ -19,9 +19,16 @@ export const defaultEvent = {
       url: 'http://www.frontendlondon.co.uk/'
     },
   ],
-  datetime: {
+  startDateTime: {
     iso: '2016-06-25T11:00:00+0000',
     date: '25',
+    month: '06',
+    monthSym: 'Jun',
+    year: '2016',
+  },
+  endDateTime: {
+    iso: '2016-06-28T11:00:00+0000',
+    date: '28',
     month: '06',
     monthSym: 'Jun',
     year: '2016',

--- a/src/server/api/controllers/events.js
+++ b/src/server/api/controllers/events.js
@@ -29,7 +29,14 @@ const allEventFields = `
     title
     url
   }
-  datetime {
+  startDateTime {
+    iso
+    date
+    month
+    monthSym
+    year
+  }
+  endDateTime {
     iso
     date
     month
@@ -77,7 +84,7 @@ export default class EventsController {
       .then((response) => response.json())
       .then((events) => {
         res.send({ list: events.data.allEvents.sort((a, b) =>
-          new Date(b.datetime.iso) - new Date(a.datetime.iso)
+          new Date(b.startDateTime.iso) - new Date(a.startDateTime.iso)
         ) });
       })
       .catch((err) => {

--- a/src/server/router/index.js
+++ b/src/server/router/index.js
@@ -32,9 +32,7 @@ const renderMarkup = (store, routerProps) => {
     </Provider>
   );
 
-  try {
-
-  const m = renderToStaticMarkup(
+  return renderToStaticMarkup(
     <DefaultTemplate
         initialState={store.getState()}
         title={mapRouteToPageTitle(routerProps.location.pathname)}
@@ -42,11 +40,6 @@ const renderMarkup = (store, routerProps) => {
       {application}
     </DefaultTemplate>
   );
-  console.log(m);
-  } catch(error) {
-    console.log(error);
-  }
-  return m;
 };
 
 const renderErrorPage = (error) => {

--- a/src/shared/components/date-bubble/index.js
+++ b/src/shared/components/date-bubble/index.js
@@ -8,10 +8,9 @@ function displayDateContent(startDateTime, endDateTime) {
     return (
       `${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year} - `
     + `${endDateTime.date} ${endDateTime.monthSym} ${endDateTime.year}`);
-  } else { // eslint-disable-line no-else-return
-    return (
-      `${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year}`);
   }
+  return (
+    `${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year}`);
 }
 
 const DateBubble = ({

--- a/src/shared/components/date-bubble/index.js
+++ b/src/shared/components/date-bubble/index.js
@@ -1,4 +1,5 @@
 // Displays date bubble
+/* eslint-disable max-len */
 
 import React, { Component } from 'react';
 import styles from './style.css';

--- a/src/shared/components/date-bubble/index.js
+++ b/src/shared/components/date-bubble/index.js
@@ -1,28 +1,38 @@
 // Displays date bubble
-/* eslint-disable max-len */
 
-import React, { Component } from 'react';
+import React, { PropTypes } from 'react';
 import styles from './style.css';
 
-export default class DateBubble extends Component {
-  static propTypes = {
-    startDate: React.PropTypes.string,
-    startMonth: React.PropTypes.string,
-    startYear: React.PropTypes.string,
-    endDate: React.PropTypes.string,
-    endMonth: React.PropTypes.string,
-    endYear: React.PropTypes.string,
-    displayDateRange: React.PropTypes.boolean,
-  };
-
-  render() {
-    const displayDate = this.props.displayDateRange ?
-      `${this.props.startDate} ${this.props.startMonth} ${this.props.startYear} - ${this.props.endDate} ${this.props.endMonth} ${this.props.endYear}`
-      : `${this.props.startDate} ${this.props.startMonth} ${this.props.startYear}`;
-    return (
-      <div className={styles.dateBubble}>
-        {displayDate}
-      </div>
-    );
+const DateBubble = ({
+  startDate,
+  startMonth,
+  startYear,
+  endDate,
+  endMonth,
+  endYear,
+  displayDateRange,
+}) => {
+  let displayDateContent = '';
+  if (displayDateRange) {
+    displayDateContent = `${startDate} ${startMonth} ${startYear} \
+    - ${endDate} ${endMonth} ${endYear}`;
+  } else {
+    displayDateContent = `${startDate} ${startMonth} ${startYear}`;
   }
-}
+
+  return (<div className={styles.dateBubble}>
+    {displayDateContent}
+  </div>);
+};
+
+DateBubble.propTypes = {
+  startDate: PropTypes.string,
+  startMonth: PropTypes.string,
+  startYear: PropTypes.string,
+  endDate: PropTypes.string,
+  endMonth: PropTypes.string,
+  endYear: PropTypes.string,
+  displayDateRange: PropTypes.bool,
+};
+
+export default DateBubble;

--- a/src/shared/components/date-bubble/index.js
+++ b/src/shared/components/date-bubble/index.js
@@ -4,20 +4,18 @@ import React, { PropTypes } from 'react';
 import styles from './style.css';
 
 const DateBubble = ({
-  startDate,
-  startMonth,
-  startYear,
-  endDate,
-  endMonth,
-  endYear,
+  startDateTime,
+  endDateTime,
   displayDateRange,
 }) => {
   let displayDateContent = '';
   if (displayDateRange) {
-    displayDateContent = `${startDate} ${startMonth} ${startYear} \
-    - ${endDate} ${endMonth} ${endYear}`;
+    displayDateContent =
+    (`${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year} - `
+    + `${endDateTime.date} ${endDateTime.monthSym} ${endDateTime.year}`);
   } else {
-    displayDateContent = `${startDate} ${startMonth} ${startYear}`;
+    displayDateContent =
+    `${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year}`;
   }
 
   return (<div className={styles.dateBubble}>
@@ -25,13 +23,15 @@ const DateBubble = ({
   </div>);
 };
 
+const dateShape = {
+  date: PropTypes.string.isRequired,
+  monthSym: PropTypes.string.isRequired,
+  year: PropTypes.string.isRequired,
+};
+
 DateBubble.propTypes = {
-  startDate: PropTypes.string,
-  startMonth: PropTypes.string,
-  startYear: PropTypes.string,
-  endDate: PropTypes.string,
-  endMonth: PropTypes.string,
-  endYear: PropTypes.string,
+  startDateTime: PropTypes.shape(dateShape),
+  endDateTime: PropTypes.shape(dateShape),
   displayDateRange: PropTypes.bool,
 };
 

--- a/src/shared/components/date-bubble/index.js
+++ b/src/shared/components/date-bubble/index.js
@@ -3,24 +3,26 @@
 import React, { PropTypes } from 'react';
 import styles from './style.css';
 
+function displayDateContent(startDateTime, endDateTime) {
+  if (endDateTime) {
+    return (
+      `${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year} - `
+    + `${endDateTime.date} ${endDateTime.monthSym} ${endDateTime.year}`);
+  } else { // eslint-disable-line no-else-return
+    return (
+      `${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year}`);
+  }
+}
+
 const DateBubble = ({
   startDateTime,
   endDateTime,
-}) => {
-  let displayDateContent = '';
-  if (endDateTime) {
-    displayDateContent =
-    (`${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year} - `
-    + `${endDateTime.date} ${endDateTime.monthSym} ${endDateTime.year}`);
-  } else {
-    displayDateContent =
-    `${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year}`;
-  }
+}) => (
+  <div className={styles.dateBubble}>
+    {displayDateContent(startDateTime, endDateTime)}
+  </div>
+);
 
-  return (<div className={styles.dateBubble}>
-    {displayDateContent}
-  </div>);
-};
 
 const dateShape = {
   date: PropTypes.string.isRequired,

--- a/src/shared/components/date-bubble/index.js
+++ b/src/shared/components/date-bubble/index.js
@@ -5,23 +5,22 @@ import styles from './style.css';
 
 export default class DateBubble extends Component {
   static propTypes = {
-    date: React.PropTypes.string,
-    month: React.PropTypes.string,
-    year: React.PropTypes.string,
+    startDate: React.PropTypes.string,
+    startMonth: React.PropTypes.string,
+    startYear: React.PropTypes.string,
+    endDate: React.PropTypes.string,
+    endMonth: React.PropTypes.string,
+    endYear: React.PropTypes.string,
+    displayDateRange: React.PropTypes.boolean,
   };
 
   render() {
+    const displayDate = this.props.displayDateRange ?
+      `${this.props.startDate} ${this.props.startMonth} ${this.props.startYear} - ${this.props.endDate} ${this.props.endMonth} ${this.props.endYear}`
+      : `${this.props.startDate} ${this.props.startMonth} ${this.props.startYear}`;
     return (
       <div className={styles.dateBubble}>
-        <div className={styles.date}>
-          {this.props.date}
-        </div>
-        <div className={styles.month}>
-          {this.props.month}
-        </div>
-        <div className={styles.year}>
-          {this.props.year}
-        </div>
+        {displayDate}
       </div>
     );
   }

--- a/src/shared/components/date-bubble/index.js
+++ b/src/shared/components/date-bubble/index.js
@@ -6,10 +6,9 @@ import styles from './style.css';
 const DateBubble = ({
   startDateTime,
   endDateTime,
-  displayDateRange,
 }) => {
   let displayDateContent = '';
-  if (displayDateRange) {
+  if (endDateTime) {
     displayDateContent =
     (`${startDateTime.date} ${startDateTime.monthSym} ${startDateTime.year} - `
     + `${endDateTime.date} ${endDateTime.monthSym} ${endDateTime.year}`);
@@ -30,9 +29,8 @@ const dateShape = {
 };
 
 DateBubble.propTypes = {
-  startDateTime: PropTypes.shape(dateShape),
+  startDateTime: PropTypes.shape(dateShape).isRequired,
   endDateTime: PropTypes.shape(dateShape),
-  displayDateRange: PropTypes.bool,
 };
 
 export default DateBubble;

--- a/src/shared/components/date-bubble/style.css
+++ b/src/shared/components/date-bubble/style.css
@@ -1,15 +1,14 @@
-@value mobile from "../variables/breakpoints.css";
+@value red from "../variables/colors.css";
 
 .dateBubble {
-  background: #be1414;
   display: inline-block;
-  font-size: 0.8em;
-  color: #fff;
+  font-size: 0.9em;
+  font-weight: bold;
+  color: red;
   text-align: center;
   text-transform: uppercase;
   min-width: 3em;
   margin-bottom: 1em;
-  padding: 0.3em 0;
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px;
@@ -18,27 +17,11 @@
 }
 
 .date {
-  font-size: 2em;
+  font-size: 0.9em;
   line-height: 1.2em;
 }
 
-.month {
-}
-
-.year {
-}
-
-@media mobile {
-  .dateBubble {
-    padding: 0.3em;
-  }
-
-  .date, .month, .year {
-    display: inline-block;
-    margin: 0 2px;
-  }
-
-  .date {
-    font-size: 1em;
-  }
+.date, .month, .year {
+  display: inline-block;
+  margin: 0 2px;
 }

--- a/src/shared/components/event-links-list/index.js
+++ b/src/shared/components/event-links-list/index.js
@@ -1,47 +1,51 @@
 // Displays list of links related to the event
 
-import React, { Component } from 'react';
+import React, { PropTypes } from 'react';
 
 import classNames from 'classnames';
 import layout from '../utils/layout.css';
 import icons from '../icons/style.css';
 import styles from './style.css';
 
-export default class EventLinksList extends Component {
-  static propTypes = {
-    linkList: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    listType: React.PropTypes.oneOf(['external', 'internal']).isRequired,
-  };
+const EventLinksList = ({
+  linkList,
+  listType,
+}) => {
+  if (linkList.length === 0) return (<noscript />);
+  return (
+    <div className={classNames({
+      [styles.eventLinkList]: true,
+      [layout.cf]: true,
+    })}>
+      {
+        linkList.map(eventLink => (
+          <a
+            className={styles.fullDetailsLink}
+            href={eventLink.url}
+            key={eventLink.url}
+            target={listType === 'external' ? '_blank' : null}
+          >
+            <span>{eventLink.title}</span>
+            <span className={classNames({
+              [icons.sketchExternalLink]: listType === 'external',
+              [icons.sketchArrowRight]: listType === 'internal',
+              [styles.externalLinkIcon]: true,
+            })}
+            />
+          </a>
+        ))
+      }
+    </div>
+  );
+};
 
-  render() {
-    if (this.props.linkList.length === 0) return null;
 
-    const { listType } = this.props;
+EventLinksList.propTypes = {
+  linkList: PropTypes.arrayOf(PropTypes.shape({
+    url: PropTypes.string,
+    title: PropTypes.string,
+  })).isRequired,
+  listType: React.PropTypes.oneOf(['external', 'internal']).isRequired,
+};
 
-    return (
-      <div className={classNames({
-        [styles.eventLinkList]: true,
-        [layout.cf]: true,
-      })}>
-        {
-          this.props.linkList.map(eventLink => (
-            <a
-              className={styles.fullDetailsLink}
-              href={eventLink.url}
-              key={eventLink.url}
-              target={listType === 'external' ? '_blank' : null}
-            >
-              <span>{eventLink.title}</span>
-              <span className={classNames({
-                [icons.sketchExternalLink]: listType === 'external',
-                [icons.sketchArrowRight]: listType === 'internal',
-                [styles.externalLinkIcon]: true,
-              })}
-              />
-            </a>
-          ))
-        }
-      </div>
-    );
-  }
-}
+export default EventLinksList;

--- a/src/shared/components/event-meta/index.js
+++ b/src/shared/components/event-meta/index.js
@@ -32,9 +32,9 @@ const EventMeta = ({
       }
       </div>
     );
-  } else { // eslint-disable-line no-else-return
-    return (<noscript />);
   }
+
+  return (<noscript />);
 };
 
 EventMeta.propTypes = {

--- a/src/shared/components/event-meta/index.js
+++ b/src/shared/components/event-meta/index.js
@@ -5,41 +5,42 @@ import TagsList from '../tags-list';
 import EventLinksList from '../event-links-list';
 
 const EventMeta = ({
-  event,
-}) => (
-  <div>
-  {
-    event.externalLinks || event.internalLinks ?
-      <div className={styles.eventLinks}>
+  internalLinks,
+  externalLinks,
+  tags,
+}) => {
+  if (internalLinks.length > 0 && externalLinks.length > 0) {
+    return (<div>
       {
-        event.externalLinks ?
-          <EventLinksList
-            linkList={event.externalLinks}
-            listType="external" />
-          : null
+        externalLinks || internalLinks ?
+          <div className={styles.eventLinks}>
+            <EventLinksList
+              linkList={externalLinks}
+              listType="external" />
+            <EventLinksList
+              linkList={internalLinks}
+              listType="internal" />
+          </div>
+        : <noscript />
       }
       {
-        event.internalLinks ?
-          <EventLinksList
-            linkList={event.internalLinks}
-            listType="internal" />
-          : null
+        tags
+        ? <TagsList
+            tags={tags}
+            tagsLinkPath="about-us/events" />
+        : <noscript />
       }
       </div>
-    : null
+    );
+  } else { // eslint-disable-line no-else-return
+    return (<noscript />);
   }
-  {
-    event.tags
-    ? <TagsList
-        tags={event.tags}
-        tagsLinkPath="about-us/events" />
-    : null
-  }
-  </div>
-);
+};
 
 EventMeta.propTypes = {
-  event: PropTypes.object.isRequired,
+  internalLinks: EventLinksList.propTypes.linkList,
+  externalLinks: EventLinksList.propTypes.linkList,
+  tags: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default EventMeta;

--- a/src/shared/components/event-meta/index.js
+++ b/src/shared/components/event-meta/index.js
@@ -6,9 +6,7 @@ import EventLinksList from '../event-links-list';
 
 const EventMeta = ({
   event,
-}) => {
-  console.log('META', event);
-  return (
+}) => (
   <div>
   {
     event.externalLinks || event.internalLinks ?
@@ -39,7 +37,6 @@ const EventMeta = ({
   }
   </div>
 );
-};
 
 EventMeta.propTypes = {
   event: PropTypes.object.isRequired,

--- a/src/shared/components/event-meta/index.spec.js
+++ b/src/shared/components/event-meta/index.spec.js
@@ -1,0 +1,16 @@
+import EventMeta from './index.js';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { defaultEvent } from '../../../../spec/fixtures/events.js';
+
+describe('EventMeta component', () => {
+  it('renders successfully with default props', () => {
+    const wrapper = shallow(<EventMeta
+      internalLinks={defaultEvent.internalLinks}
+      externalLinks={defaultEvent.externalLinks}
+      tags={defaultEvent.tags}
+    />);
+    expect(wrapper.find('div').length).to.equal(2);
+  });
+});

--- a/src/shared/components/event-title/index.js
+++ b/src/shared/components/event-title/index.js
@@ -1,0 +1,31 @@
+import React, { PropTypes } from 'react';
+import styles from './style.css';
+import classNames from 'classnames';
+import icons from '../icons/style.css';
+
+const EventTitle = ({
+  eventTitle,
+  eventHref,
+}) => (
+  <a className={styles.eventTitleLink}
+    href={eventHref}>
+    <h2 className={styles.eventTitle}>
+      <span>
+        {eventTitle}
+      </span>
+      <span className={classNames(
+        {
+          [styles.arrow]: true,
+          [icons.sketchArrowRight]: true,
+        })}
+      />
+    </h2>
+  </a>
+);
+
+EventTitle.propTypes = {
+  eventTitle: PropTypes.string.isRequired,
+  eventHref: PropTypes.string.isRequired,
+};
+
+export default EventTitle;

--- a/src/shared/components/event-title/index.js
+++ b/src/shared/components/event-title/index.js
@@ -1,7 +1,8 @@
 import React, { PropTypes } from 'react';
-import styles from './style.css';
 import classNames from 'classnames';
 import icons from '../icons/style.css';
+import styles from './style.css';
+import { h2 } from '../typography/style.css';
 
 const EventTitle = ({
   eventTitle,
@@ -9,7 +10,10 @@ const EventTitle = ({
 }) => (
   <a className={styles.eventTitleLink}
     href={eventHref}>
-    <h2 className={styles.eventTitle}>
+    <h2 className={classNames({
+      [styles.eventTitle]: true,
+      [h2]: true,
+    })}>
       <span>
         {eventTitle}
       </span>

--- a/src/shared/components/event-title/index.spec.js
+++ b/src/shared/components/event-title/index.spec.js
@@ -1,0 +1,14 @@
+import EventTitle from './index.js';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+describe('EventTitle component', () => {
+  it('renders successfully with default props', () => {
+    const wrapper = shallow(<EventTitle
+      eventTitle={'Event title'}
+      eventHref={'https://www.red-badger.com'}
+    />);
+    expect(wrapper.find('h2').length).to.equal(1);
+  });
+});

--- a/src/shared/components/event-title/style.css
+++ b/src/shared/components/event-title/style.css
@@ -5,7 +5,6 @@
 }
 
 .eventTitle {
-  composes: h2 from "../../components/typography/style.css";
   font-size: 1.6em;
   text-decoration: none;
   display: inline;

--- a/src/shared/components/event-title/style.css
+++ b/src/shared/components/event-title/style.css
@@ -1,0 +1,23 @@
+@value red from "../variables/colors.css";
+
+.eventTitleLink {
+  text-decoration: none;
+}
+
+.eventTitle {
+  composes: h2 from "../../components/typography/style.css";
+  font-size: 1.6em;
+  text-decoration: none;
+  display: inline;
+  margin: 0 0 20px 0;
+  float: left;
+  text-align: left;
+}
+
+.eventTitle span {
+  display: inline;
+}
+
+.eventTitle:hover, .eventTitle:active, .eventTitle:focus {
+  color: red;
+}

--- a/src/shared/components/event-title/style.css
+++ b/src/shared/components/event-title/style.css
@@ -20,3 +20,8 @@
 .eventTitle:hover, .eventTitle:active, .eventTitle:focus {
   color: red;
 }
+
+.arrow {
+  color: red;
+  padding-left: 5px;
+}

--- a/src/shared/components/events-list-entry/index.js
+++ b/src/shared/components/events-list-entry/index.js
@@ -40,7 +40,11 @@ const EventsListEntry = ({
             <div className={styles.eventDescription}>
               {event.strapline}
             </div>
-            <EventMeta event={event} />
+            <EventMeta
+              internalLinks={event.internalLinks}
+              externalLinks={event.externalLinks}
+              tags={event.tags}
+             />
           </Cell>
           <Cell size={4} key='event_picture' breakOn="mobileS"
             hideOn="mobileS">

--- a/src/shared/components/events-list-entry/index.js
+++ b/src/shared/components/events-list-entry/index.js
@@ -12,10 +12,7 @@ import { eventHref } from '../../util/event';
 const EventsListEntry = ({
   event,
   timeline,
-}) => {
-  console.log('EVENT', event);
-  console.log('TIMELINE', timeline);
-  return (
+}) => (
   <li key={`event_${event.id}`} className={styles.eventItem}>
     <Grid fit={false}>
       <Cell size={12}>
@@ -56,8 +53,6 @@ const EventsListEntry = ({
     </Grid>
   </li>
 );
-};
-
 
 EventsListEntry.propTypes = {
   event: PropTypes.object.isRequired,

--- a/src/shared/components/events-list-entry/index.spec.js
+++ b/src/shared/components/events-list-entry/index.spec.js
@@ -1,0 +1,15 @@
+import EventsListEntry from './index.js';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { defaultEvent } from '../../../../spec/fixtures/events.js';
+
+describe('EventsListEntry component', () => {
+  it('renders successfully with default props', () => {
+    const wrapper = shallow(<EventsListEntry
+      timeline="past"
+      event={defaultEvent}
+    />);
+    expect(wrapper.find('li').length).to.equal(1);
+  });
+});

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -60,9 +60,13 @@ export default class EventsList extends Component {
                       <Cell size={12}>
                         <HR color="grey" customClassName={styles.mobileHorizontalLine} />
                         <DateBubble
-                            date={event.startDateTime.date}
-                            month={event.startDateTime.monthSym}
-                            year={event.startDateTime.year}
+                            startDate={event.startDateTime.date}
+                            startMonth={event.startDateTime.monthSym}
+                            startYear={event.startDateTime.year}
+                            endDate={event.endDateTime.date}
+                            endMonth={event.endDateTime.monthSym}
+                            endYear={event.endDateTime.year}
+                            displayDateRange={(this.props.timeline === 'today' && event.startDateTime.date !== event.endDateTime.date)}
                         />
                       </Cell>
                       <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -57,7 +57,7 @@ export default class EventsList extends Component {
               relevantEvents.map((event) => (
                   <li key={`event_${event.id}`} className={styles.eventItem}>
                     <Grid fit={false}>
-                      <Cell size={1} breakOn="mobile">
+                      <Cell size={12}>
                         <HR color="grey" customClassName={styles.mobileHorizontalLine} />
                         <DateBubble
                             date={event.datetime.date}
@@ -68,8 +68,7 @@ export default class EventsList extends Component {
                       <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">
                         <EventImage imgPath={ imageAssetsEndpoint + (event.featureImageFilename ? event.featureImageFilename : 'red-badger-event.jpg') } href={eventHref(event)} />
                       </Cell>
-                      <Cell size={11} breakOn="mobile">
-                        <HR color="grey" customClassName={styles.wideHorizontalLine} />
+                      <Cell size={12} breakOn="mobile">
                         <Grid fit={false}>
                           <Cell size={8} key='event_description' breakOn="mobileS">
                             <a className={styles.eventTitleLink} href={eventHref(event)}>

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -2,8 +2,6 @@
 // You can request only displaying events of past or future
 // with the `timeline` prop
 
-/* eslint-disable max-len */
-
 import React, { PropTypes } from 'react';
 import styles from './style.css';
 
@@ -17,6 +15,7 @@ import icons from '../icons/style.css';
 
 import TagsList from '../tags-list';
 import EventLinksList from '../event-links-list';
+import EventsTimelineTitle from '../events-timeline-title';
 import { eventHref } from '../../util/event';
 import { splitEvents } from '../../util/split-events';
 
@@ -37,25 +36,15 @@ const EventsList = ({
   if (relevantEvents.length > 0) {
     return (
       <div className={styles.eventsListTimelineSection}>
-          {(() => {
-            switch (timeline) {
-              case 'past':
-                return (<h2>Past events</h2>);
-              case 'future':
-                return (<h2>Upcoming events</h2>);
-              case 'today':
-                return (<h2>Today</h2>);
-              default:
-                return null;
-            }
-          })()}
+          <EventsTimelineTitle timeline={timeline} />
         <ul className={styles.eventsList}>
           {
             relevantEvents.map((event) => (
                 <li key={`event_${event.id}`} className={styles.eventItem}>
                   <Grid fit={false}>
                     <Cell size={12}>
-                      <HR color="grey" customClassName={styles.mobileHorizontalLine} />
+                      <HR color="grey" customClassName=
+                        {styles.mobileHorizontalLine} />
                       <DateBubble
                           startDate={event.startDateTime.date}
                           startMonth={event.startDateTime.monthSym}
@@ -63,16 +52,23 @@ const EventsList = ({
                           endDate={event.endDateTime.date}
                           endMonth={event.endDateTime.monthSym}
                           endYear={event.endDateTime.year}
-                          displayDateRange={(timeline === 'today' && event.startDateTime.date !== event.endDateTime.date)}
+                          displayDateRange={(timeline === 'today' &&
+                            event.startDateTime.date !==
+                              event.endDateTime.date)}
                       />
                     </Cell>
                     <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">
-                      <EventImage imgPath={ imageAssetsEndpoint + (event.featureImageFilename ? event.featureImageFilename : 'red-badger-event.jpg') } href={eventHref(event)} />
+                      <EventImage imgPath={ imageAssetsEndpoint +
+                        (event.featureImageFilename ?
+                          event.featureImageFilename :
+                          'red-badger-event.jpg') } href={eventHref(event)} />
                     </Cell>
                     <Cell size={12} breakOn="mobile">
                       <Grid fit={false}>
-                        <Cell size={8} key='event_description' breakOn="mobileS">
-                          <a className={styles.eventTitleLink} href={eventHref(event)}>
+                        <Cell size={8} key='event_description'
+                          breakOn="mobileS">
+                          <a className={styles.eventTitleLink}
+                            href={eventHref(event)}>
                             <h2 className={styles.eventTitle}>
                               <span>
                                 {event.title}
@@ -116,8 +112,13 @@ const EventsList = ({
                             : null
                           }
                         </Cell>
-                        <Cell size={4} key='event_picture' breakOn="mobileS" hideOn="mobileS">
-                          <EventImage imgPath={ imageAssetsEndpoint + (event.featureImageFilename ? event.featureImageFilename : 'red-badger-event.jpg') } href={eventHref(event)} />
+                        <Cell size={4} key='event_picture' breakOn="mobileS"
+                          hideOn="mobileS">
+                          <EventImage imgPath={ imageAssetsEndpoint +
+                            (event.featureImageFilename ?
+                              event.featureImageFilename :
+                                'red-badger-event.jpg') }
+                            href={eventHref(event)} />
                         </Cell>
                       </Grid>
                     </Cell>

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -16,7 +16,7 @@ import EventLinksList from '../event-links-list';
 import EventsTimelineTitle from '../events-timeline-title';
 import EventTitle from '../event-title';
 import { eventHref } from '../../util/event';
-import { splitEvents } from '../../util/split-events';
+import { splitEvents, setEndDate } from '../../util/events';
 
 const EventsList = ({
   events,
@@ -45,10 +45,10 @@ const EventsList = ({
                         {styles.mobileHorizontalLine} />
                       <DateBubble
                           startDateTime={event.startDateTime}
-                          endDateTime={event.endDateTime}
-                          displayDateRange={(timeline === 'today' &&
-                            event.startDateTime.date !==
-                              event.endDateTime.date)}
+                          endDateTime={setEndDate(
+                            timeline,
+                            event.startDateTime,
+                            event.endDateTime)}
                       />
                     </Cell>
                     <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -6,7 +6,6 @@ import React, { PropTypes } from 'react';
 import styles from './style.css';
 
 import EventImage from '../event-image';
-import { imageAssetsEndpoint } from '../../config';
 import DateBubble from '../date-bubble';
 import HR from '../hr';
 import { Grid, Cell } from '../grid';
@@ -95,10 +94,8 @@ const EventsList = ({
                         </Cell>
                         <Cell size={4} key='event_picture' breakOn="mobileS"
                           hideOn="mobileS">
-                          <EventImage imgPath={ imageAssetsEndpoint +
-                            (event.featureImageFilename ?
-                              event.featureImageFilename :
-                                'red-badger-event.jpg') }
+                          <EventImage
+                            imgPath={eventImagePath(event.featureImageFilename)}
                             href={eventHref(event)} />
                         </Cell>
                       </Grid>

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -31,6 +31,7 @@ const EventsList = ({
               <EventsListEntry
                 event={event}
                 timeline={timeline}
+                key={`key_${event.id}`}
               />
             ))
           }
@@ -39,7 +40,7 @@ const EventsList = ({
     );
   }
 
-  return null;
+  return (<noscript />);
 };
 
 EventsList.propTypes = {

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -16,7 +16,7 @@ import EventLinksList from '../event-links-list';
 import EventsTimelineTitle from '../events-timeline-title';
 import EventTitle from '../event-title';
 import { eventHref } from '../../util/event';
-import { splitEvents, setEndDate } from '../../util/events';
+import { splitEvents, setEndDate, eventImagePath } from '../../util/events';
 
 const EventsList = ({
   events,
@@ -52,10 +52,9 @@ const EventsList = ({
                       />
                     </Cell>
                     <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">
-                      <EventImage imgPath={ imageAssetsEndpoint +
-                        (event.featureImageFilename ?
-                          event.featureImageFilename :
-                          'red-badger-event.jpg') } href={eventHref(event)} />
+                      <EventImage
+                        imgPath={eventImagePath(event.featureImageFilename)}
+                        href={eventHref(event)} />
                     </Cell>
                     <Cell size={12} breakOn="mobile">
                       <Grid fit={false}>

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -10,12 +10,11 @@ import { imageAssetsEndpoint } from '../../config';
 import DateBubble from '../date-bubble';
 import HR from '../hr';
 import { Grid, Cell } from '../grid';
-import classNames from 'classnames';
-import icons from '../icons/style.css';
 
 import TagsList from '../tags-list';
 import EventLinksList from '../event-links-list';
 import EventsTimelineTitle from '../events-timeline-title';
+import EventTitle from '../event-title';
 import { eventHref } from '../../util/event';
 import { splitEvents } from '../../util/split-events';
 
@@ -29,7 +28,6 @@ const EventsList = ({
       events,
       timeline,
       reverse: timeline === 'future',
-      todayDateTime: new Date(),
     })
     : events;
 
@@ -46,12 +44,8 @@ const EventsList = ({
                       <HR color="grey" customClassName=
                         {styles.mobileHorizontalLine} />
                       <DateBubble
-                          startDate={event.startDateTime.date}
-                          startMonth={event.startDateTime.monthSym}
-                          startYear={event.startDateTime.year}
-                          endDate={event.endDateTime.date}
-                          endMonth={event.endDateTime.monthSym}
-                          endYear={event.endDateTime.year}
+                          startDateTime={event.startDateTime}
+                          endDateTime={event.endDateTime}
                           displayDateRange={(timeline === 'today' &&
                             event.startDateTime.date !==
                               event.endDateTime.date)}
@@ -67,20 +61,8 @@ const EventsList = ({
                       <Grid fit={false}>
                         <Cell size={8} key='event_description'
                           breakOn="mobileS">
-                          <a className={styles.eventTitleLink}
-                            href={eventHref(event)}>
-                            <h2 className={styles.eventTitle}>
-                              <span>
-                                {event.title}
-                              </span>
-                              <span className={classNames(
-                                {
-                                  [styles.arrow]: true,
-                                  [icons.sketchArrowRight]: true,
-                                })}
-                              />
-                            </h2>
-                          </a>
+                          <EventTitle eventTitle={event.title}
+                            eventHref={eventHref(event)} />
                           <div className={styles.eventDescription}>
                             {event.strapline}
                           </div>

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -60,9 +60,9 @@ export default class EventsList extends Component {
                       <Cell size={12}>
                         <HR color="grey" customClassName={styles.mobileHorizontalLine} />
                         <DateBubble
-                            date={event.datetime.date}
-                            month={event.datetime.monthSym}
-                            year={event.datetime.year}
+                            date={event.startDateTime.date}
+                            month={event.startDateTime.monthSym}
+                            year={event.startDateTime.year}
                         />
                       </Cell>
                       <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -114,7 +114,7 @@ const EventsList = ({
 
 EventsList.propTypes = {
   events: PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  timeline: EventsTimelineTitle.propTypes.timeline,
+  timeline: PropTypes.oneOf(['past', 'future', 'today']).isRequired,
 };
 
 export default EventsList;

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -4,7 +4,7 @@
 
 /* eslint-disable max-len */
 
-import React, { Component } from 'react';
+import React, { PropTypes } from 'react';
 import styles from './style.css';
 
 import EventImage from '../event-image';
@@ -20,119 +20,122 @@ import EventLinksList from '../event-links-list';
 import { eventHref } from '../../util/event';
 import { splitEvents } from '../../util/split-events';
 
-export default class EventsList extends Component {
-  static propTypes = {
-    events: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    timeline: React.PropTypes.oneOf(['past', 'future', 'today']),
-  };
+const EventsList = ({
+  events,
+  timeline,
+}) => {
+  const relevantEvents =
+    timeline
+    ? splitEvents({
+      events,
+      timeline,
+      reverse: timeline === 'future',
+      todayDateTime: new Date(),
+    })
+    : events;
 
-  render() {
-    const relevantEvents =
-      this.props.timeline
-      ? splitEvents({
-        events: this.props.events,
-        timeline: this.props.timeline,
-        reverse: this.props.timeline === 'future',
-        todayDateTime: new Date(),
-      })
-      : this.props.events;
-
-    if (relevantEvents.length > 0) {
-      return (
-        <div className={styles.eventsListTimelineSection}>
-            {(() => {
-              switch (this.props.timeline) {
-                case 'past':
-                  return (<h2>Past events</h2>);
-                case 'future':
-                  return (<h2>Upcoming events</h2>);
-                case 'today':
-                  return (<h2>Today</h2>);
-                default:
-                  return null;
-              }
-            })()}
-          <ul className={styles.eventsList}>
-            {
-              relevantEvents.map((event) => (
-                  <li key={`event_${event.id}`} className={styles.eventItem}>
-                    <Grid fit={false}>
-                      <Cell size={12}>
-                        <HR color="grey" customClassName={styles.mobileHorizontalLine} />
-                        <DateBubble
-                            startDate={event.startDateTime.date}
-                            startMonth={event.startDateTime.monthSym}
-                            startYear={event.startDateTime.year}
-                            endDate={event.endDateTime.date}
-                            endMonth={event.endDateTime.monthSym}
-                            endYear={event.endDateTime.year}
-                            displayDateRange={(this.props.timeline === 'today' && event.startDateTime.date !== event.endDateTime.date)}
-                        />
-                      </Cell>
-                      <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">
-                        <EventImage imgPath={ imageAssetsEndpoint + (event.featureImageFilename ? event.featureImageFilename : 'red-badger-event.jpg') } href={eventHref(event)} />
-                      </Cell>
-                      <Cell size={12} breakOn="mobile">
-                        <Grid fit={false}>
-                          <Cell size={8} key='event_description' breakOn="mobileS">
-                            <a className={styles.eventTitleLink} href={eventHref(event)}>
-                              <h2 className={styles.eventTitle}>
-                                <span>
-                                  {event.title}
-                                </span>
-                                <span className={classNames(
-                                  {
-                                    [styles.arrow]: true,
-                                    [icons.sketchArrowRight]: true,
-                                  })}
-                                />
-                              </h2>
-                            </a>
-                            <div className={styles.eventDescription}>
-                              {event.strapline}
-                            </div>
-                            {
-                              event.externalLinks || event.internalLinks ?
-                                <div className={styles.eventLinks}>
-                                {
-                                  event.externalLinks ?
-                                    <EventLinksList
-                                      linkList={event.externalLinks}
-                                      listType="external" />
-                                    : null
-                                }
-                                {
-                                  event.internalLinks ?
-                                    <EventLinksList
-                                      linkList={event.internalLinks}
-                                      listType="internal" />
-                                    : null
-                                }
-                                </div>
-                              : null
-                            }
-                            {
-                              event.tags
-                              ? <TagsList
-                                  tags={event.tags}
-                                  tagsLinkPath="about-us/events" />
-                              : null
-                            }
-                          </Cell>
-                          <Cell size={4} key='event_picture' breakOn="mobileS" hideOn="mobileS">
-                            <EventImage imgPath={ imageAssetsEndpoint + (event.featureImageFilename ? event.featureImageFilename : 'red-badger-event.jpg') } href={eventHref(event)} />
-                          </Cell>
-                        </Grid>
-                      </Cell>
-                    </Grid>
-                  </li>
-              ))
+  if (relevantEvents.length > 0) {
+    return (
+      <div className={styles.eventsListTimelineSection}>
+          {(() => {
+            switch (timeline) {
+              case 'past':
+                return (<h2>Past events</h2>);
+              case 'future':
+                return (<h2>Upcoming events</h2>);
+              case 'today':
+                return (<h2>Today</h2>);
+              default:
+                return null;
             }
-          </ul>
-        </div>
-      );
-    }
-
-    return null;
+          })()}
+        <ul className={styles.eventsList}>
+          {
+            relevantEvents.map((event) => (
+                <li key={`event_${event.id}`} className={styles.eventItem}>
+                  <Grid fit={false}>
+                    <Cell size={12}>
+                      <HR color="grey" customClassName={styles.mobileHorizontalLine} />
+                      <DateBubble
+                          startDate={event.startDateTime.date}
+                          startMonth={event.startDateTime.monthSym}
+                          startYear={event.startDateTime.year}
+                          endDate={event.endDateTime.date}
+                          endMonth={event.endDateTime.monthSym}
+                          endYear={event.endDateTime.year}
+                          displayDateRange={(timeline === 'today' && event.startDateTime.date !== event.endDateTime.date)}
+                      />
+                    </Cell>
+                    <Cell size={1} key="event_picture_mobile" hideOn="mobileSM">
+                      <EventImage imgPath={ imageAssetsEndpoint + (event.featureImageFilename ? event.featureImageFilename : 'red-badger-event.jpg') } href={eventHref(event)} />
+                    </Cell>
+                    <Cell size={12} breakOn="mobile">
+                      <Grid fit={false}>
+                        <Cell size={8} key='event_description' breakOn="mobileS">
+                          <a className={styles.eventTitleLink} href={eventHref(event)}>
+                            <h2 className={styles.eventTitle}>
+                              <span>
+                                {event.title}
+                              </span>
+                              <span className={classNames(
+                                {
+                                  [styles.arrow]: true,
+                                  [icons.sketchArrowRight]: true,
+                                })}
+                              />
+                            </h2>
+                          </a>
+                          <div className={styles.eventDescription}>
+                            {event.strapline}
+                          </div>
+                          {
+                            event.externalLinks || event.internalLinks ?
+                              <div className={styles.eventLinks}>
+                              {
+                                event.externalLinks ?
+                                  <EventLinksList
+                                    linkList={event.externalLinks}
+                                    listType="external" />
+                                  : null
+                              }
+                              {
+                                event.internalLinks ?
+                                  <EventLinksList
+                                    linkList={event.internalLinks}
+                                    listType="internal" />
+                                  : null
+                              }
+                              </div>
+                            : null
+                          }
+                          {
+                            event.tags
+                            ? <TagsList
+                                tags={event.tags}
+                                tagsLinkPath="about-us/events" />
+                            : null
+                          }
+                        </Cell>
+                        <Cell size={4} key='event_picture' breakOn="mobileS" hideOn="mobileS">
+                          <EventImage imgPath={ imageAssetsEndpoint + (event.featureImageFilename ? event.featureImageFilename : 'red-badger-event.jpg') } href={eventHref(event)} />
+                        </Cell>
+                      </Grid>
+                    </Cell>
+                  </Grid>
+                </li>
+            ))
+          }
+        </ul>
+      </div>
+    );
   }
-}
+
+  return null;
+};
+
+EventsList.propTypes = {
+  events: PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  timeline: PropTypes.oneOf(['past', 'future', 'today']),
+};
+
+export default EventsList;

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -114,7 +114,7 @@ const EventsList = ({
 
 EventsList.propTypes = {
   events: PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  timeline: PropTypes.oneOf(['past', 'future', 'today']).isRequired,
+  timeline: EventsTimelineTitle.propTypes.timeline,
 };
 
 export default EventsList;

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -114,7 +114,7 @@ const EventsList = ({
 
 EventsList.propTypes = {
   events: PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  timeline: PropTypes.oneOf(['past', 'future', 'today']),
+  timeline: EventsTimelineTitle.propTypes.timeline,
 };
 
 export default EventsList;

--- a/src/shared/components/events-list/index.js
+++ b/src/shared/components/events-list/index.js
@@ -29,13 +29,13 @@ export default class EventsList extends Component {
   render() {
     const relevantEvents =
       this.props.timeline
-      ? splitEvents(
-        this.props.events,
-        this.props.timeline,
-        { reverse: this.props.timeline === 'future' }
-      )
+      ? splitEvents({
+        events: this.props.events,
+        timeline: this.props.timeline,
+        reverse: this.props.timeline === 'future',
+        todayDateTime: new Date(),
+      })
       : this.props.events;
-
 
     if (relevantEvents.length > 0) {
       return (

--- a/src/shared/components/events-list/index.spec.js
+++ b/src/shared/components/events-list/index.spec.js
@@ -1,0 +1,17 @@
+import EventsList from './index.js';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { defaultEvent } from '../../../../spec/fixtures/events.js';
+
+describe('EventsList component', () => {
+  it('renders successfully with default props', () => {
+    const wrapper = shallow(<EventsList
+      timeline="past"
+      events={[
+        defaultEvent,
+      ]}
+    />);
+    expect(wrapper.find('ul').length).to.equal(1);
+  });
+});

--- a/src/shared/components/events-list/index.spec.js
+++ b/src/shared/components/events-list/index.spec.js
@@ -12,6 +12,6 @@ describe('EventsList component', () => {
         defaultEvent,
       ]}
     />);
-    expect(wrapper.find('li').length).to.equal(1);
+    expect(wrapper.find('ul').length).to.equal(1);
   });
 });

--- a/src/shared/components/events-list/index.spec.js
+++ b/src/shared/components/events-list/index.spec.js
@@ -12,6 +12,6 @@ describe('EventsList component', () => {
         defaultEvent,
       ]}
     />);
-    expect(wrapper.find('ul').length).to.equal(1);
+    expect(wrapper.find('li').length).to.equal(1);
   });
 });

--- a/src/shared/components/events-list/style.css
+++ b/src/shared/components/events-list/style.css
@@ -14,10 +14,6 @@
   text-align: center;
 }
 
-.eventsListTimelineSection h2.eventTitle {
-  text-align: left;
-}
-
 .eventsList {
   font-size: 1em;
   margin-top: 0;
@@ -27,27 +23,6 @@
 .eventItem {
   position: relative;
   list-style-type: none;
-}
-
-.eventTitleLink {
-  text-decoration: none;
-}
-
-.eventTitle {
-  composes: h2 from "../../components/typography/style.css";
-  font-size: 1.6em;
-  text-decoration: none;
-  display: inline;
-  margin: 0 0 20px 0;
-  float: left;
-}
-
-.eventTitle span {
-  display: inline;
-}
-
-.eventTitle:hover, .eventTitle:active, .eventTitle:focus {
-  color: red;
 }
 
 .arrow {

--- a/src/shared/components/events-list/style.css
+++ b/src/shared/components/events-list/style.css
@@ -66,19 +66,11 @@
 }
 
 .mobileHorizontalLine {
-  display: none;
+  display: block;
   margin: 1.5em 0 0 0;
 }
 
 @media mobile {
-  .wideHorizontalLine {
-    display: none;
-  }
-
-  .mobileHorizontalLine {
-    display: block;
-  }
-
   .eventsList {
     padding: 0;
   }

--- a/src/shared/components/events-timeline-title/index.js
+++ b/src/shared/components/events-timeline-title/index.js
@@ -16,7 +16,7 @@ const EventsTimelineTitle = ({
 };
 
 EventsTimelineTitle.propTypes = {
-  timeline: PropTypes.string.isRequired,
+  timeline: PropTypes.oneOf(['past', 'future', 'today']).isRequired,
 };
 
 export default EventsTimelineTitle;

--- a/src/shared/components/events-timeline-title/index.js
+++ b/src/shared/components/events-timeline-title/index.js
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react';
+
+const EventsTimelineTitle = ({
+  timeline,
+}) => {
+  switch (timeline) {
+    case 'past':
+      return (<h2>Past events</h2>);
+    case 'future':
+      return (<h2>Upcoming events</h2>);
+    case 'today':
+      return (<h2>Today</h2>);
+    default:
+      return null;
+  }
+};
+
+EventsTimelineTitle.propTypes = {
+  timeline: PropTypes.string.isRequired,
+};
+
+export default EventsTimelineTitle;

--- a/src/shared/components/events-timeline-title/index.spec.js
+++ b/src/shared/components/events-timeline-title/index.spec.js
@@ -4,8 +4,26 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
 describe('EventsTimelineTitle component', () => {
-  it('renders successfully with timeline provided', () => {
+  it('renders successfully with today timeline provided', () => {
     const wrapper = shallow(<EventsTimelineTitle timeline="today" />);
     expect(wrapper.find('h2').length).to.equal(1);
+    expect(wrapper.find('h2').text()).to.equal('Today');
+  });
+
+  it('renders successfully with future timeline provided', () => {
+    const wrapper = shallow(<EventsTimelineTitle timeline="future" />);
+    expect(wrapper.find('h2').length).to.equal(1);
+    expect(wrapper.find('h2').text()).to.equal('Upcoming events');
+  });
+
+  it('renders successfully with past timeline provided', () => {
+    const wrapper = shallow(<EventsTimelineTitle timeline="past" />);
+    expect(wrapper.find('h2').length).to.equal(1);
+    expect(wrapper.find('h2').text()).to.equal('Past events');
+  });
+
+  it('does not return a result if not passed a timeline proeprty', () => {
+    const wrapper = shallow(<EventsTimelineTitle />);
+    expect(wrapper.find('h2').length).to.equal(0);
   });
 });

--- a/src/shared/components/events-timeline-title/index.spec.js
+++ b/src/shared/components/events-timeline-title/index.spec.js
@@ -1,0 +1,17 @@
+import EventsTimelineTitle from './index.js';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+describe('EventsTimelineTitle component', () => {
+  it('renders successfully with timeline provided', () => {
+    const wrapper = shallow(<EventsTimelineTitle timeline="today" />);
+    expect(wrapper.find('h2').length).to.equal(1);
+  });
+
+  it('renders null with wrong timeline value provided', () => {
+    const wrapper = shallow(<EventsTimelineTitle timeline="aaa" />);
+    expect(wrapper.find('h2').length).to.equal(0);
+    expect(wrapper.nodes).to.deep.equal([null]);
+  });
+});

--- a/src/shared/components/events-timeline-title/index.spec.js
+++ b/src/shared/components/events-timeline-title/index.spec.js
@@ -8,10 +8,4 @@ describe('EventsTimelineTitle component', () => {
     const wrapper = shallow(<EventsTimelineTitle timeline="today" />);
     expect(wrapper.find('h2').length).to.equal(1);
   });
-
-  it('renders null with wrong timeline value provided', () => {
-    const wrapper = shallow(<EventsTimelineTitle timeline="aaa" />);
-    expect(wrapper.find('h2').length).to.equal(0);
-    expect(wrapper.nodes).to.deep.equal([null]);
-  });
 });

--- a/src/shared/containers/event/index.js
+++ b/src/shared/containers/event/index.js
@@ -14,7 +14,7 @@ import DateBubble from '../../components/date-bubble';
 import EventsSideList from '../../components/events-side-list';
 import EventLinksList from '../../components/event-links-list';
 import TagsList from '../../components/tags-list';
-import { splitEvents } from '../../util/split-events';
+import { splitEvents, setEndDate } from '../../util/events';
 
 import marked from 'marked';
 import Helmet from 'react-helmet';
@@ -46,7 +46,10 @@ export class Event extends Component {
                   customClassName={styles.mobileHorizontalLine} />
                 <DateBubble
                     startDateTime={event.startDateTime}
-                    endDateTime={event.endDateTime}
+                    endDateTime={setEndDate(
+                      'today',
+                      event.startDateTime,
+                      event.endDateTime)}
                 />
               </Cell>
               <Cell size={8} breakOn="mobile">

--- a/src/shared/containers/event/index.js
+++ b/src/shared/containers/event/index.js
@@ -12,8 +12,8 @@ import HR from '../../components/hr';
 import { Grid, Cell } from '../../components/grid';
 import DateBubble from '../../components/date-bubble';
 import EventsSideList from '../../components/events-side-list';
-import EventLinksList from '../../components/event-links-list';
-import TagsList from '../../components/tags-list';
+import EventMeta from '../../components/event-meta';
+
 import { splitEvents, setEndDate } from '../../util/events';
 
 import marked from 'marked';
@@ -70,35 +70,11 @@ export class Event extends Component {
                         )
                       }
                     </div>
-                    {
-                      event.externalLinks || event.internalLinks ?
-                        <div className={styles.eventLinks}>
-                          {
-                            event.externalLinks ?
-                              <EventLinksList
-                                linkList={event.externalLinks}
-                                listType="external" />
-                              : null
-                          }
-                          {
-                            event.internalLinks ?
-                              <EventLinksList
-                                linkList={event.internalLinks}
-                                listType="internal" />
-                              : null
-                          }
-                        </div>
-                        : null
-                    }
-                    {
-                      event.tags.length ? (
-                        <div className={styles.eventTags}>
-                          <TagsList
-                            tags={event.tags}
-                            tagsLinkPath="about-us/events" />
-                        </div>
-                      ) : null
-                    }
+                    <EventMeta
+                      internalLinks={event.internalLinks}
+                      externalLinks={event.externalLinks}
+                      tags={event.tags}
+                     />
                   </Cell>
                 </Grid>
                 <HR color="grey" />

--- a/src/shared/containers/event/index.js
+++ b/src/shared/containers/event/index.js
@@ -24,8 +24,15 @@ export class Event extends Component {
 
   render() {
     const { event, events } = this.props;
-    let futureEvents = splitEvents(events, 'future', { reverse: true });
-    let todayEvents = splitEvents(events, 'today');
+    const futureEvents = splitEvents({
+      events,
+      timeline: 'future',
+      reverse: true,
+    });
+    const todayEvents = splitEvents({
+      events,
+      timeline: 'today',
+    });
 
 
     return (
@@ -38,9 +45,8 @@ export class Event extends Component {
                 <HR color="grey"
                   customClassName={styles.mobileHorizontalLine} />
                 <DateBubble
-                    date={event.startDateTime.date}
-                    month={event.startDateTime.monthSym}
-                    year={event.startDateTime.year}
+                    startDateTime={event.startDateTime}
+                    endDateTime={event.endDateTime}
                 />
               </Cell>
               <Cell size={8} breakOn="mobile">

--- a/src/shared/containers/event/index.js
+++ b/src/shared/containers/event/index.js
@@ -38,9 +38,9 @@ export class Event extends Component {
                 <HR color="grey"
                   customClassName={styles.mobileHorizontalLine} />
                 <DateBubble
-                    date={event.datetime.date}
-                    month={event.datetime.monthSym}
-                    year={event.datetime.year}
+                    date={event.startDateTime.date}
+                    month={event.startDateTime.monthSym}
+                    year={event.startDateTime.year}
                 />
               </Cell>
               <Cell size={8} breakOn="mobile">

--- a/src/shared/containers/event/index.js
+++ b/src/shared/containers/event/index.js
@@ -34,7 +34,7 @@ export class Event extends Component {
         <Section>
           <Container>
             <Grid fit={false}>
-              <Cell size={1} breakOn="mobile">
+              <Cell size={12} breakOn="mobile">
                 <HR color="grey"
                   customClassName={styles.mobileHorizontalLine} />
                 <DateBubble
@@ -44,9 +44,8 @@ export class Event extends Component {
                 />
               </Cell>
               <Cell size={8} breakOn="mobile">
-                <HR color="grey" customClassName={styles.wideHorizontalLine} />
                 <Grid fit={false}>
-                  <Cell size={11} key='event_description' breakOn="mobileS">
+                  <Cell size={12} key='event_description' breakOn="mobileS">
                     <h2 className={styles.eventTitle}>
                       {event.title}
                     </h2>

--- a/src/shared/util/event.js
+++ b/src/shared/util/event.js
@@ -1,4 +1,4 @@
 /* eslint-disable max-len */
 export function eventHref(event) {
-  return `/about-us/events/${event.datetime.year}/${event.datetime.month}/${event.datetime.date}/${event.slug}`;
+  return `/about-us/events/${event.startDateTime.year}/${event.startDateTime.month}/${event.startDateTime.date}/${event.slug}`;
 }

--- a/src/shared/util/events.js
+++ b/src/shared/util/events.js
@@ -4,10 +4,8 @@ export function splitEvents({
   events,              // array of events
   timeline,            // one of 'past', 'today', 'future'
   reverse = false,     // optionally reverse final list of events
-  todayDateTime = null,  // iso string representing today date
+  todayDateTime = new Date(),  // iso string representing today date
 }) {
-  const today = todayDateTime || new Date();
-
   let relevantEvents = events.filter(event => {
     const startDateTime = dateFns.parse(event.startDateTime.iso);
     const endDateTime = dateFns.parse(event.endDateTime.iso);
@@ -21,15 +19,15 @@ export function splitEvents({
     switch (timeline) {
       case 'today':
         if (dateFns.isSameDay(startDateTime, endDateTime)) {
-          return dateFns.isSameDay(startDateTime, today);
+          return dateFns.isSameDay(startDateTime, todayDateTime);
         } else { // eslint-disable-line no-else-return
-          return dateFns.isWithinRange(today, startDateTime, endDateTime);
+          return dateFns.isWithinRange(todayDateTime, startDateTime, endDateTime);
         }
       case 'past':
-        return (!dateFns.isWithinRange(today, startDateTime, endDateTime) && dateFns.isBefore(endDateTime, today) && !dateFns.isSameDay(endDateTime, today));
+        return (!dateFns.isWithinRange(todayDateTime, startDateTime, endDateTime) && dateFns.isBefore(endDateTime, todayDateTime) && !dateFns.isSameDay(endDateTime, todayDateTime));
       case 'future':
-        return (!dateFns.isSameDay(startDateTime, today) &&
-          dateFns.isAfter(startDateTime, today));
+        return (!dateFns.isSameDay(startDateTime, todayDateTime) &&
+          dateFns.isAfter(startDateTime, todayDateTime));
       default:
         return false;
     }
@@ -40,4 +38,15 @@ export function splitEvents({
   }
 
   return relevantEvents;
+}
+
+// Helper function for displaying date range for multi day events
+// Date range would only be displayed if end date is set on the
+// child component
+export function setEndDate(timeline, startDateTime, endDateTime) {
+  if (timeline === 'today' &&
+    startDateTime.date !== endDateTime.date) {
+    return endDateTime;
+  }
+  return null;
 }

--- a/src/shared/util/events.js
+++ b/src/shared/util/events.js
@@ -53,6 +53,7 @@ export function setEndDate(timeline, startDateTime, endDateTime) {
 }
 
 export function eventImagePath(
-  featureImageFilename = 'red-badger-event.jpg') {
-  return imageAssetsEndpoint + featureImageFilename;
+  featureImageFilename) {
+  const f = featureImageFilename || 'red-badger-event.jpg';
+  return imageAssetsEndpoint + f;
 }

--- a/src/shared/util/events.js
+++ b/src/shared/util/events.js
@@ -1,4 +1,5 @@
 import dateFns from 'date-fns';
+import { imageAssetsEndpoint } from '../config';
 
 export function splitEvents({
   events,              // array of events
@@ -49,4 +50,9 @@ export function setEndDate(timeline, startDateTime, endDateTime) {
     return endDateTime;
   }
   return null;
+}
+
+export function eventImagePath(
+  featureImageFilename = 'red-badger-event.jpg') {
+  return imageAssetsEndpoint + featureImageFilename;
 }

--- a/src/shared/util/events.js
+++ b/src/shared/util/events.js
@@ -12,8 +12,9 @@ export function splitEvents({
     const endDateTime = dateFns.parse(event.endDateTime.iso);
 
     // In a rare case of user error we omit this event from the output list
-    if (!dateFns.isSameDay(startDateTime, endDateTime) &&
-      !dateFns.isBefore(startDateTime, endDateTime)) {
+    if ((!dateFns.isSameDay(startDateTime, endDateTime) &&
+      !dateFns.isBefore(startDateTime, endDateTime)) ||
+        dateFns.differenceInMinutes(endDateTime, startDateTime) < 0) {
       return false;
     }
 

--- a/src/shared/util/events.spec.js
+++ b/src/shared/util/events.spec.js
@@ -11,6 +11,7 @@ let testEventsSingleDay = [];
 let testEventsMultiDay = [];
 let testEventsMultiDayInProgress = [];
 let testErrorMultiDay = [];
+let testEventsSingleDayWrongStartEndTime = [];
 let currentDate;
 
 describe('Set end date', () => {
@@ -217,7 +218,28 @@ describe('SplitEvents', () => {
         },
       },
     ];
+
+    testEventsSingleDayWrongStartEndTime = [
+      {
+        id: 'earlier-event',
+        startDateTime: {
+          iso: earlierToday,
+        },
+        endDateTime: {
+          iso: laterToday,
+        },
+      },
+      {
+        id: 'later-today-event',
+        startDateTime: {
+          iso: laterToday,
+        },
+        endDateTime: {
+          iso: earlierToday,
+        },
+      }];
   });
+
 
   afterEach(() => {
     MockDate.reset();
@@ -329,6 +351,17 @@ describe('SplitEvents', () => {
       expect(returnedEvents.length).to.equal(2);
       expect(returnedEvents[0].id).to.equal('future-event-2');
       expect(returnedEvents[1].id).to.equal('future-event-1');
+    });
+
+    it('omits event from the result if end time is earlier than start time', () => {
+      const timeline = 'today';
+      const returnedEvents = splitEvents({
+        events: testEventsSingleDayWrongStartEndTime,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(1);
+      expect(returnedEvents[0].id).to.equal('earlier-event');
     });
   });
 });

--- a/src/shared/util/events.spec.js
+++ b/src/shared/util/events.spec.js
@@ -1,5 +1,10 @@
-import { splitEvents } from './events';
+/* eslint-disable no-multi-str */
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-unused-vars */
+
+import { splitEvents, setEndDate, eventImagePath } from './events';
 import { expect } from 'chai';
+import { imageAssetsEndpoint } from '../config';
 import * as MockDate from 'mockdate';
 
 let testEventsSingleDay = [];
@@ -7,6 +12,43 @@ let testEventsMultiDay = [];
 let testEventsMultiDayInProgress = [];
 let testErrorMultiDay = [];
 let currentDate;
+
+describe('Set end date', () => {
+  const startDateTime = {
+    date: 5,
+  };
+  const endDateTime = {
+    date: 8,
+  };
+
+  it('returns end date when timeline is set to today \
+    and start date is different', () => {
+    expect(setEndDate('today', startDateTime, endDateTime))
+      .to.deep.equal(endDateTime);
+  });
+
+  it('returns null when timeline is not set to today \
+    and start date is different', () => {
+    expect(setEndDate('past', startDateTime, endDateTime)).to.be.null;
+  });
+
+  it('returns null when timeline is set to today \
+    and start date is same', () => {
+    const endDateTimeToday = {
+      date: 5,
+    };
+    expect(setEndDate('past', startDateTime, endDateTimeToday)).to.be.null;
+  });
+});
+
+describe('Event image path', () => {
+  it('returns full image path when image filename is provided', () => {
+    expect(eventImagePath('hi.jpg')).to.equal('//res.cloudinary.com/red-badger-assets/image/upload/events/hi.jpg');
+  });
+  it('returns default image path when image filename is not provided', () => {
+    expect(eventImagePath()).to.equal('//res.cloudinary.com/red-badger-assets/image/upload/events/red-badger-event.jpg');
+  });
+});
 
 describe('SplitEvents', () => {
   beforeEach(() => {

--- a/src/shared/util/events.spec.js
+++ b/src/shared/util/events.spec.js
@@ -1,4 +1,4 @@
-import { splitEvents } from './split-events';
+import { splitEvents } from './events';
 import { expect } from 'chai';
 import * as MockDate from 'mockdate';
 

--- a/src/shared/util/events.spec.js
+++ b/src/shared/util/events.spec.js
@@ -41,7 +41,7 @@ describe('Set end date', () => {
   });
 });
 
-describe.only('Event image path', () => {
+describe('Event image path', () => {
   it('returns full image path when image filename is provided', () => {
     expect(eventImagePath('hi.jpg')).to.equal('//res.cloudinary.com/red-badger-assets/image/upload/events/hi.jpg');
   });

--- a/src/shared/util/events.spec.js
+++ b/src/shared/util/events.spec.js
@@ -41,12 +41,15 @@ describe('Set end date', () => {
   });
 });
 
-describe('Event image path', () => {
+describe.only('Event image path', () => {
   it('returns full image path when image filename is provided', () => {
     expect(eventImagePath('hi.jpg')).to.equal('//res.cloudinary.com/red-badger-assets/image/upload/events/hi.jpg');
   });
   it('returns default image path when image filename is not provided', () => {
     expect(eventImagePath()).to.equal('//res.cloudinary.com/red-badger-assets/image/upload/events/red-badger-event.jpg');
+  });
+  it('returns default image path when image filename is null', () => {
+    expect(eventImagePath(null)).to.equal('//res.cloudinary.com/red-badger-assets/image/upload/events/red-badger-event.jpg');
   });
 });
 

--- a/src/shared/util/split-events.js
+++ b/src/shared/util/split-events.js
@@ -2,7 +2,7 @@ import dateFns from 'date-fns';
 
 export function splitEvents(events, timeline, { reverse = false } = {}) {
   let relevantEvents = events.filter(event => {
-    const d = dateFns.parse(event.datetime.iso);
+    const d = dateFns.parse(event.startDateTime.iso);
     switch (timeline) {
       case 'today':
         return dateFns.isToday(d);

--- a/src/shared/util/split-events.js
+++ b/src/shared/util/split-events.js
@@ -1,20 +1,43 @@
 import dateFns from 'date-fns';
 
-export function splitEvents(events, timeline, { reverse = false } = {}) {
+export function splitEvents({
+  events,              // array of events
+  timeline,            // one of 'past', 'today', 'future'
+  reverse = false,     // optionally reverse final list of events
+  todayDateTime = null,  // iso string representing today date
+}) {
+  const today = todayDateTime || new Date();
+
   let relevantEvents = events.filter(event => {
-    const d = dateFns.parse(event.startDateTime.iso);
+    const startDateTime = dateFns.parse(event.startDateTime.iso);
+    const endDateTime = dateFns.parse(event.endDateTime.iso);
+
+    // In a rare case of user error we omit this event from the output list
+    if (!dateFns.isSameDay(startDateTime, endDateTime) &&
+      !dateFns.isBefore(startDateTime, endDateTime)) {
+      return false;
+    }
+
     switch (timeline) {
       case 'today':
-        return dateFns.isToday(d);
+        if (dateFns.isSameDay(startDateTime, endDateTime)) {
+          return dateFns.isSameDay(startDateTime, today);
+        } else { // eslint-disable-line no-else-return
+          return dateFns.isWithinRange(today, startDateTime, endDateTime);
+        }
       case 'past':
-        return (dateFns.isPast(d) && !dateFns.isToday(d));
+        return (!dateFns.isWithinRange(today, startDateTime, endDateTime) && dateFns.isBefore(endDateTime, today) && !dateFns.isSameDay(endDateTime, today));
+      case 'future':
+        return (!dateFns.isSameDay(startDateTime, today) &&
+          dateFns.isAfter(startDateTime, today));
       default:
-        return (dateFns.isFuture(d) && !dateFns.isToday(d));
+        return false;
     }
   }, this);
 
   if (relevantEvents.length > 1 && reverse === true) {
     relevantEvents = relevantEvents.reverse();
   }
+
   return relevantEvents;
 }

--- a/src/shared/util/split-events.spec.js
+++ b/src/shared/util/split-events.spec.js
@@ -2,13 +2,17 @@ import { splitEvents } from './split-events';
 import { expect } from 'chai';
 import * as MockDate from 'mockdate';
 
-let testevents = [];
+let testEventsSingleDay = [];
+let testEventsMultiDay = [];
+let testEventsMultiDayInProgress = [];
+let testErrorMultiDay = [];
+let currentDate;
 
 describe('SplitEvents', () => {
   beforeEach(() => {
     MockDate.set('Thu Jun 23 2016 14:10:56 GMT+0100 (BST)');
 
-    const currentDate = new Date();
+    currentDate = new Date();
 
     const laterToday = new Date();
     laterToday.setHours(currentDate.getHours() + 1);
@@ -22,7 +26,79 @@ describe('SplitEvents', () => {
     const previousDate = new Date();
     previousDate.setDate(previousDate.getDate() - 5);
 
-    testevents = [
+    const threeDaysAgo = new Date();
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    testEventsMultiDay = [
+      {
+        id: 'past-multi-day-event',
+        startDateTime: {
+          iso: previousDate,
+        },
+        endDateTime: {
+          iso: threeDaysAgo,
+        },
+      },
+      {
+        id: 'today-multi-day-event',
+        startDateTime: {
+          iso: currentDate,
+        },
+        endDateTime: {
+          iso: futureDate,
+        },
+      },
+      {
+        id: 'future-multi-day-event',
+        startDateTime: {
+          iso: tomorrow,
+        },
+        endDateTime: {
+          iso: futureDate,
+        },
+      },
+    ];
+
+    testErrorMultiDay = [
+      {
+        id: 'today-multi-day-event',
+        startDateTime: {
+          iso: tomorrow,
+        },
+        endDateTime: {
+          iso: yesterday,
+        },
+      },
+    ];
+
+    testEventsMultiDayInProgress = [
+      {
+        id: 'past-multi-day-event',
+        startDateTime: {
+          iso: previousDate,
+        },
+        endDateTime: {
+          iso: threeDaysAgo,
+        },
+      },
+      {
+        id: 'yesterday-tomorrow-multi-day-event',
+        startDateTime: {
+          iso: yesterday,
+        },
+        endDateTime: {
+          iso: futureDate,
+        },
+      },
+    ];
+
+    testEventsSingleDay = [
       {
         id: 'past-event-1',
         startDateTime: {
@@ -102,37 +178,112 @@ describe('SplitEvents', () => {
     MockDate.reset();
   });
 
-  it('returns future events', () => {
-    const timeline = 'future';
-    const returnedEvents = splitEvents(testevents, timeline);
-    expect(returnedEvents.length).to.equal(2);
-    expect(returnedEvents[0].id).to.equal('future-event-1');
-    expect(returnedEvents[1].id).to.equal('future-event-2');
+  describe('multi day events', () => {
+    it('omits events with end date earlier then start date from final list', () => {
+      const timeline = 'today';
+      const returnedEvents = splitEvents({
+        events: testErrorMultiDay,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(0);
+    });
+
+    it('returns todays events correctly when event start date is today and end date is tomorrow', () => {
+      const timeline = 'today';
+      const returnedEvents = splitEvents({
+        events: testEventsMultiDay,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(1);
+      expect(returnedEvents[0].id).to.equal('today-multi-day-event');
+    });
+
+    it('returns todays events correctly when event start date was yesterday and end date is tomorrow', () => {
+      const timeline = 'today';
+      const returnedEvents = splitEvents({
+        events: testEventsMultiDayInProgress,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(1);
+      expect(returnedEvents[0].id).to.equal('yesterday-tomorrow-multi-day-event');
+    });
+
+    it('returns future events correctly for upcoming multiday events', () => {
+      const timeline = 'future';
+      const returnedEvents = splitEvents({
+        events: testEventsMultiDay,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(1);
+      expect(returnedEvents[0].id).to.equal('future-multi-day-event');
+    });
+
+    it('returns past events correctly for multiday events', () => {
+      const timeline = 'past';
+      const returnedEvents = splitEvents({
+        events: testEventsMultiDay,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(1);
+      expect(returnedEvents[0].id).to.equal('past-multi-day-event');
+    });
   });
 
-  it('returns past events', () => {
-    const timeline = 'past';
-    const returnedEvents = splitEvents(testevents, timeline);
-    expect(returnedEvents.length).to.equal(2);
-    expect(returnedEvents[0].id).to.equal('past-event-1');
-    expect(returnedEvents[1].id).to.equal('past-event-2');
-  });
+  describe('single day events', () => {
+    it('returns future events', () => {
+      const timeline = 'future';
+      const returnedEvents = splitEvents({
+        events: testEventsSingleDay,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(2);
+      expect(returnedEvents[0].id).to.equal('future-event-1');
+      expect(returnedEvents[1].id).to.equal('future-event-2');
+    });
 
-  it('returns todays events', () => {
-    const timeline = 'today';
-    const returnedEvents = splitEvents(testevents, timeline);
-    expect(returnedEvents.length).to.equal(4);
-    expect(returnedEvents[0].id).to.equal('today-event-1');
-    expect(returnedEvents[1].id).to.equal('today-event-2');
-    expect(returnedEvents[2].id).to.equal('later-today-event');
-    expect(returnedEvents[3].id).to.equal('earlier-today-event');
-  });
+    it('returns past events', () => {
+      const timeline = 'past';
+      const returnedEvents = splitEvents({
+        events: testEventsSingleDay,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(2);
+      expect(returnedEvents[0].id).to.equal('past-event-1');
+      expect(returnedEvents[1].id).to.equal('past-event-2');
+    });
 
-  it('returns events in reverse order when specified', () => {
-    const timeline = 'future';
-    const returnedEvents = splitEvents(testevents, timeline, { reverse: true });
-    expect(returnedEvents.length).to.equal(2);
-    expect(returnedEvents[0].id).to.equal('future-event-2');
-    expect(returnedEvents[1].id).to.equal('future-event-1');
+    it('returns todays events', () => {
+      const timeline = 'today';
+      const returnedEvents = splitEvents({
+        events: testEventsSingleDay,
+        timeline,
+        todayDateTime: currentDate,
+      });
+      expect(returnedEvents.length).to.equal(4);
+      expect(returnedEvents[0].id).to.equal('today-event-1');
+      expect(returnedEvents[1].id).to.equal('today-event-2');
+      expect(returnedEvents[2].id).to.equal('later-today-event');
+      expect(returnedEvents[3].id).to.equal('earlier-today-event');
+    });
+
+    it('returns events in reverse order when specified', () => {
+      const timeline = 'future';
+      const returnedEvents = splitEvents({
+        events: testEventsSingleDay,
+        timeline,
+        todayDateTime: currentDate,
+        reverse: true,
+      });
+      expect(returnedEvents.length).to.equal(2);
+      expect(returnedEvents[0].id).to.equal('future-event-2');
+      expect(returnedEvents[1].id).to.equal('future-event-1');
+    });
   });
 });

--- a/src/shared/util/split-events.spec.js
+++ b/src/shared/util/split-events.spec.js
@@ -25,49 +25,73 @@ describe('SplitEvents', () => {
     testevents = [
       {
         id: 'past-event-1',
-        datetime: {
+        startDateTime: {
+          iso: previousDate,
+        },
+        endDateTime: {
           iso: previousDate,
         },
       },
       {
         id: 'past-event-2',
-        datetime: {
+        startDateTime: {
+          iso: previousDate,
+        },
+        endDateTime: {
           iso: previousDate,
         },
       },
       {
         id: 'today-event-1',
-        datetime: {
+        startDateTime: {
+          iso: currentDate,
+        },
+        endDateTime: {
           iso: currentDate,
         },
       },
       {
         id: 'today-event-2',
-        datetime: {
+        startDateTime: {
+          iso: currentDate,
+        },
+        endDateTime: {
           iso: currentDate,
         },
       },
       {
         id: 'later-today-event',
-        datetime: {
+        startDateTime: {
+          iso: laterToday,
+        },
+        endDateTime: {
           iso: laterToday,
         },
       },
       {
         id: 'earlier-today-event',
-        datetime: {
+        startDateTime: {
+          iso: earlierToday,
+        },
+        endDateTime: {
           iso: earlierToday,
         },
       },
       {
         id: 'future-event-1',
-        datetime: {
+        startDateTime: {
+          iso: futureDate,
+        },
+        endDateTime: {
           iso: futureDate,
         },
       },
       {
         id: 'future-event-2',
-        datetime: {
+        startDateTime: {
+          iso: futureDate,
+        },
+        endDateTime: {
           iso: futureDate,
         },
       },


### PR DESCRIPTION
![giphy 10](https://cloud.githubusercontent.com/assets/487468/16808331/ffb27f2a-4913-11e6-83f4-3572036ab0a9.gif)

# Motivation

Currently it is only possible to specify datetime of the event. With this change we are introducing ability to specify start datetime and end datetime. Events spanning multiple days will have those days displayed in the UI (under `Today` list).

![designing_in_cross-functional_teams___red_badger](https://cloud.githubusercontent.com/assets/487468/17102993/ef81031a-5273-11e6-8fd3-4258cb1dce34.png)

- [x] Event stays in “Upcoming” list, using the first day of event for order.
- [x] When the first day of event is today, move to “Today” list. Still showing the same date range
- [x] When the last day of event is gone, move to “past” list. Use the last day of event for order.
- [x] Tests
- [x] Gif added

