### PR TITLE
Pass type correctly to eventNewsHref

### DIFF
--- a/src/shared/components/events-news-side-list/index.js
+++ b/src/shared/components/events-news-side-list/index.js
@@ -42,7 +42,7 @@ const EventsNewsSideList = ({
                 month: entryDateTime.month,
                 date: entryDateTime.date,
                 slug: entry.slug,
-                entryType,
+                type: entryType,
               })} key={i}>
                 {entry.title}
               </a>


### PR DESCRIPTION
Solves https://github.com/redbadger/website-honestly/issues/199

We were passing type incorrectly to the eventNewsHref function, causing upcoming event links to go to `/about-us/news/...` instead of `/about-us/events/...`